### PR TITLE
Vdh plot logic

### DIFF
--- a/SSINS/Catalog_Plot.py
+++ b/SSINS/Catalog_Plot.py
@@ -10,6 +10,7 @@ import numpy as np
 from SSINS import util
 from SSINS.plot_lib import image_plot, hist_plot
 import platform
+import warnings
 
 
 pol_dict_keys = np.arange(-8, 5)
@@ -135,7 +136,9 @@ def VDH_plot(SS, prefix, file_ext='pdf', xlabel='', xscale='linear', yscale='log
 
     fig, ax = plt.subplots()
 
-    if post_flag and SS.flag_choice is not None:
+    if post_flag:
+        if SS.flag_choice is None:
+            warnings.warn("Asking to plot post-flagging data, but SS.flag_choice is None. This is identical to plotting pre-flagging data")
         if post_model:
             model_func = SS.mixture_prob
         else:

--- a/SSINS/Catalog_Plot.py
+++ b/SSINS/Catalog_Plot.py
@@ -135,12 +135,12 @@ def VDH_plot(SS, prefix, file_ext='pdf', xlabel='', xscale='linear', yscale='log
 
     fig, ax = plt.subplots()
 
-    if pre_model or post_model:
-        model_func = SS.mixture_prob
-    else:
+    if not (pre_model or post_model):
         model_func = None
 
     if post_flag and SS.flag_choice is not None:
+        if post_model:
+            model_func = SS.mixture_prob
         hist_plot(fig, ax, np.abs(SS.data_array[np.logical_not(SS.data_array.mask)]),
                   bins=bins, legend=legend, model_func=model_func,
                   yscale=yscale, ylim=ylim, density=density, label=post_label,
@@ -148,6 +148,8 @@ def VDH_plot(SS, prefix, file_ext='pdf', xlabel='', xscale='linear', yscale='log
                   model_label=post_model_label, color=post_color,
                   model_color=post_model_color, font_size=font_size)
     if pre_flag:
+        if pre_model:
+            model_func = SS.mixture_prob
         if SS.flag_choice is not 'original':
             temp_flags = np.copy(SS.data_array.mask)
             temp_choice = '%s' % SS.flag_choice

--- a/SSINS/Catalog_Plot.py
+++ b/SSINS/Catalog_Plot.py
@@ -135,12 +135,11 @@ def VDH_plot(SS, prefix, file_ext='pdf', xlabel='', xscale='linear', yscale='log
 
     fig, ax = plt.subplots()
 
-    if not (pre_model or post_model):
-        model_func = None
-
     if post_flag and SS.flag_choice is not None:
         if post_model:
             model_func = SS.mixture_prob
+        else:
+            model_func = None
         hist_plot(fig, ax, np.abs(SS.data_array[np.logical_not(SS.data_array.mask)]),
                   bins=bins, legend=legend, model_func=model_func,
                   yscale=yscale, ylim=ylim, density=density, label=post_label,
@@ -150,6 +149,8 @@ def VDH_plot(SS, prefix, file_ext='pdf', xlabel='', xscale='linear', yscale='log
     if pre_flag:
         if pre_model:
             model_func = SS.mixture_prob
+        else:
+            model_func = None
         if SS.flag_choice is not 'original':
             temp_flags = np.copy(SS.data_array.mask)
             temp_choice = '%s' % SS.flag_choice


### PR DESCRIPTION
The logic has been changed so that the model_func variable is evaluated independently for pre_model and post_model. Previously if either of these was set to True, the model_func variable was set to SS.mixture_prob, regardless of whether one was set to False. 

The individual if blocks that plot the pre and post-flagged data now have if statements that ask whether model_func should be set to None or SS.mixture_prob. This decouples the logic.

What cannot be done is a post_flag model when only plotting pre_flagged data, which could be of interest to some.