### PR TITLE
convert slice bounds to int on write

### DIFF
--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -222,7 +222,7 @@ class INS(UVFlag):
             for event in self.match_events:
                 yaml_dict['time_ind'].append(event[0])
                 # Convert slice object to just its bounds
-                freq_bounds = [event[1].start, event[1].stop]
+                freq_bounds = [int(event[1].start), int(event[1].stop)]
                 yaml_dict['freq_bounds'].append(freq_bounds)
                 yaml_dict['shape'].append(event[2])
                 yaml_dict['sig'].append(event[3])


### PR DESCRIPTION
It seems the earlier bug was not fixed by the previous change (although it was a good change). This change actually fixes the bug, which is that a numpy.int64 cannot be written into a yaml file using safe_dump.