### PR TITLE
Sig thresh dict back compat

### DIFF
--- a/SSINS/match_filter.py
+++ b/SSINS/match_filter.py
@@ -20,11 +20,12 @@ class MF(object):
         """
         Args:
             freq_array: Sets the freq_array attribute of the filter
-            sig_thresh (dict): A dictionary where the keys are the desired
+            sig_thresh (dict or number): If dictionary, the keys are the desired
                 shapes to flag. The values are the desired significance
                 thresholds for each shape. If streak or narrow are True, thresholds
                 for these must be included in this dictionary, although they
-                should not be included in the shape_dict keyword input.
+                should not be included in the shape_dict keyword input. If passing
+                a number, this number is used as the threshold for all shapes.
             shape_dict (dict): A dictionary of shapes to flag. Keys are shapes
                 other than 'streak' and 'narrow'. Values are frequency limits
                 of corresponding shape.
@@ -46,9 +47,15 @@ class MF(object):
            See apply_samp_thresh() documentation for exact meaning."""
         self.slice_dict = self._shape_slicer(narrow, streak)
         """A dictionary whose keys are the same as shape_dict and whose values are corresponding slices into the freq_array attribute"""
-        for shape in self.slice_dict:
-            if shape not in self.sig_thresh.keys():
-                raise KeyError("%s shape has no sig_thresh. Check sig_thresh input." % shape)
+        if type(self.sig_thresh) is dict:
+            for shape in self.slice_dict:
+                if shape not in self.sig_thresh.keys():
+                    raise KeyError("%s shape has no sig_thresh. Check sig_thresh input." % shape)
+        else:
+            sig_thresh_dict = {}
+            for shape in self.slice_dict:
+                sig_thresh_dict[shape] = self.sig_thresh
+            self.sig_thresh = sig_thresh_dict
 
     def _shape_slicer(self, narrow, streak):
 

--- a/SSINS/tests/test_MF.py
+++ b/SSINS/tests/test_MF.py
@@ -16,13 +16,14 @@ def test_init():
     ch_width = freqs[1] - freqs[0]
     shape = [freqs[0] - 0.1 * ch_width, freqs[4] + 0.1 * ch_width]
     shape_dict = {'shape': shape}
-    sig_thresh = {'narrow': 5, 'shape': 5, 'streak': 5}
+    sig_thresh = {'narrow': 10, 'shape': 5, 'streak': 5}
 
     mf_1 = MF(freqs, sig_thresh, shape_dict=shape_dict)
 
     assert mf_1.slice_dict['shape'] == slice(0, 5), "It did not set the shape correctly"
     assert mf_1.slice_dict['narrow'] is None, "narrow did not get set correctly"
     assert mf_1.slice_dict['streak'] == slice(0, 384), "streak did not get set correctly"
+    assert mf_1.sig_thresh == sig_thresh
 
     # Test disabling streak/narrow
     mf_2 = MF(freqs, sig_thresh, shape_dict=shape_dict, narrow=False, streak=False)
@@ -42,6 +43,10 @@ def test_init():
         mf_4 = MF(freqs, {'narrow': 5}, shape_dict={'shape': shape})
     except KeyError:
         pass
+
+    # Test passing a number to shape_dict
+    mf_5 = MF(freqs, 5, shape_dict={'shape': shape})
+    assert mf_5.sig_thresh == {'shape': 5, 'narrow': 5, 'streak': 5}
 
 
 def test_match_test():

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -200,7 +200,7 @@ Flagging an INS using a match_filter (MF)
   ...               'TV8': [1.88e8, 1.95e8],
   ...               'TV9': [1.95e8, 2.02e8]}
   >>> # We also need to apply significance thresholds for each shape, including 'narrow' and 'streak'
-  >>> # In principle, these can be different values per shape
+  >>> # In principle, these can be different values per shape, see advanced techniques.
   >>> sig_thresh = 5
   >>> mf = MF(ins.freq_array, sig_thresh, shape_dict=shape_dict, streak=True, narrow=True)
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -187,7 +187,7 @@ Flagging an INS using a match_filter (MF)
   >>> # The MF class requires a frequency array and significance threshold as positional arguments
   >>> # We will disable searching for broadband streaks and provide no additional sub-bands for the filter
   >>> # First we need to define a sig_thresh dictionary for our only shape (narrowband)
-  >>> sig_thresh = {'narrow': 5}
+  >>> sig_thresh = 5
   >>> mf = MF(ins.freq_array, sig_thresh, streak=False, narrow=True, shape_dict={})
 
 (b) Constructing a filter for streaks and Western Australian DTV in MWA EoR Highband
@@ -201,12 +201,7 @@ Flagging an INS using a match_filter (MF)
   ...               'TV9': [1.95e8, 2.02e8]}
   >>> # We also need to apply significance thresholds for each shape, including 'narrow' and 'streak'
   >>> # In principle, these can be different values per shape
-  >>> sig_thresh = {'narrow': 5,
-  ...               'streak': 5,
-  ...               'TV6': 5,
-  ...               'TV7': 5,
-  ...               'TV8': 5,
-  ...               'TV9': 5}
+  >>> sig_thresh = 5
   >>> mf = MF(ins.freq_array, sig_thresh, shape_dict=shape_dict, streak=True, narrow=True)
 
 (c) Constructing a filter for streaks and South African DTV in HERA below 200 Mhz
@@ -220,11 +215,7 @@ Flagging an INS using a match_filter (MF)
   >>> # Technically 2 Mhz of channel 7 should appear, but we omit that in this example
   >>> # We also need to apply significance thresholds for each shape, including 'narrow' and 'streak'
   >>> # In principle, these can be different values per shape
-  >>> sig_thresh = {'narrow': 5,
-                    'streak': 5,
-                    'TV4': 5,
-                    'TV5': 5,
-                    'TV6': 5}
+  >>> sig_thresh = 5
   >>> mf = MF(ins.freq_array, sig_thresh, shape_dict=shape_dict, streak=True)
 
 (d) Using the filter to flag the noise spectrum
@@ -236,18 +227,21 @@ Flagging an INS using a match_filter (MF)
   ...               'TV7': [1.81e8, 1.88e8],
   ...               'TV8': [1.88e8, 1.95e8],
   ...               'TV9': [1.95e8, 2.02e8]}
-  >>> sig_thresh = {'narrow': 5,
-  ...               'streak': 5,
-  ...               'TV6': 5,
-  ...               'TV7': 5,
-  ...               'TV8': 5,
-  ...               'TV9': 5}
+  >>> sig_thresh = 5
   >>> mf = MF(ins.freq_array, sig_thresh, shape_dict=shape_dict, streak=True)
 
   >>> # Use the apply_match_test method to flag the INS (this applies the flags to the mask of the metric array)
   >>> mf.apply_match_test(ins) # doctest: +SKIP
 
-(e) Applying INS flags to an SS object and writing a new raw data file
+(e) Saving the INS mask out to an h5 file
+*****************************************
+::
+  >>> # Just use the write method as above, with the right output_type
+  >>> ins.write(prefix, output_type='mask', clobber=True)
+  >>> print(os.path.exists('%s_SSINS_mask.h5' % prefix))
+  True
+
+(f) Applying INS flags to an SS object and writing a new raw data file
 **********************************************************************
 ::
   >>> # We can use the apply_flags method to apply flags from an INS object
@@ -266,14 +260,6 @@ Flagging an INS using a match_filter (MF)
   >>> ss.write(filename_out, 'uvfits', filename_in=filename_in, combine=True,
   ...          read_kwargs={'times': times})
   >>> print(os.path.exists(filename_out))
-  True
-
-(f) Saving the INS mask out to an h5 file
-*****************************************
-::
-  >>> # Just use the write method as above, with the right output_type
-  >>> ins.write(prefix, output_type='mask', clobber=True)
-  >>> print(os.path.exists('%s_SSINS_mask.h5' % prefix))
   True
 
 (g) Getting time propagated flags from the INS mask
@@ -375,3 +361,17 @@ Extra Flagging Bits
 ::
   >>> # The total occupancy can be calculated from the flag mask with a one-liner
   >>> occ = np.mean(ins.metric_array.mask)
+
+
+(c) Setting different significance thresholds per shape
+*******************************************************
+::
+  >>> # One may pass a dictionary of significance thresholds to set different
+  >>> # thresholds per shape. All desired shapes, including narrow and broad if
+  >>> # desired, must be included.
+  >>> sig_thresh = {'narrow': 5, 'streak': 20, 'TV6': 5, 'TV7': 5, 'TV8': 5, 'TV9': 5}
+  >>> shape_dict = {'TV6': [1.74e8, 1.81e8],
+  ...               'TV7': [1.81e8, 1.88e8],
+  ...               'TV8': [1.88e8, 1.95e8],
+  ...               'TV9': [1.95e8, 2.02e8]}
+  >>> mf = MF(ins.freq_array, sig_thresh, shape_dict=shape_dict)


### PR DESCRIPTION
This lets the user pass a single number for the threshold, similar to old functionality, so that users do not need to change their scripts if they do not want to take advantage of the new multi-threshold functionality.