### PR TITLE
add -v/-p/-g options to highflag script

### DIFF
--- a/Scripts/MWA_EoR_High_Flag.py
+++ b/Scripts/MWA_EoR_High_Flag.py
@@ -3,16 +3,33 @@ import argparse
 from astropy.time import Time
 from matplotlib import cm
 import numpy as np
+from time import time
+
+# note on performance: enabling the -p plots flag takes approximately an order
+# longer than only -w writing the data files: for raw processing of data, disabling
+# -p is recommended.
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-i', '--ins_file_list', help="A text file of SSINS h5 data files")
-    parser.add_argument('-o', '--outdir', help="The output directory for the files")
-    parser.add_argument('-w', '--write', action='store_true', help="Whether to write output files in addition to plots.")
+    parser = argparse.ArgumentParser(description='Processes a list of SSINS data files into plots, CSV for occ_csv, and/or processed data.')
+    parser.add_argument('-i', '--ins_file_list', help="A text file of SSINS h5 data files.")
+    parser.add_argument('-o', '--outdir', help="The output directory for the files.")
+    parser.add_argument('-w', '--write', action='store_true', help="Toggles creation of output data files.")
+    parser.add_argument('-v', '--verbose', action='store_true', help="Toggles verbose console output of file processing progress.")
+    parser.add_argument('-p', '--plots', action='store_true', help="Toggles creation of plots.")
+    parser.add_argument('-g', '--gencsv', action='store_true', help="Toggles creation of CSV for occ_csv script.")
     args = parser.parse_args()
 
     ins_file_list = util.make_obslist(args.ins_file_list)
+
+    if args.gencsv:
+        f = open("occcsv.csv", "w") #wipe old file
+        f.write("obsid,ins_file,mask_file,yml_file\n")#header
+        f = open("occcsv.csv", "a")
+
+    #time the full length of the run if -v passed
+    if args.verbose:
+        start = time()
 
     for ins_filepath in ins_file_list:
         slash_ind = ins_filepath.rfind('/')
@@ -43,21 +60,45 @@ if __name__ == "__main__":
         for tick in yticks:
             yticklabels.append(Time(ins.time_array[tick], format='jd').iso[:-4])
 
-        Catalog_Plot.INS_plot(ins, prefix, xticks=xticks, yticks=yticks,
-                              xticklabels=xticklabels, yticklabels=yticklabels,
-                              data_cmap=cm.plasma, ms_vmin=-5, ms_vmax=5,
-                              title=obsid, xlabel='Frequency (Mhz)', ylabel='Time (UTC)')
+        #write plots if command flagged to do so
+        if args.plots:
+            Catalog_Plot.INS_plot(ins, prefix, xticks=xticks, yticks=yticks,
+                                  xticklabels=xticklabels, yticklabels=yticklabels,
+                                  data_cmap=cm.plasma, ms_vmin=-5, ms_vmax=5,
+                                  title=obsid, xlabel='Frequency (Mhz)', ylabel='Time (UTC)')
+            if args.verbose:
+                print("wrote trimmed zeromask for "+obsid)
 
         mf.apply_match_test(ins, apply_samp_thresh=False)
         mf.apply_samp_thresh_test(ins, event_record=True)
 
         flagged_prefix = '%s/%s_trimmed_zeromask_MF_s8' % (args.outdir, obsid)
+
+        #write data/mask/match/ if command flagged to do so
         if args.write:
             ins.write(flagged_prefix, output_type='data', clobber=True)
             ins.write(flagged_prefix, output_type='mask', clobber=True)
             ins.write(flagged_prefix, output_type='match_events')
+            if args.verbose:
+                print("wrote data/mask/match files for "+obsid)
 
-        Catalog_Plot.INS_plot(ins, flagged_prefix, xticks=xticks, yticks=yticks,
-                              xticklabels=xticklabels, yticklabels=yticklabels,
-                              data_cmap=cm.plasma, ms_vmin=-5, ms_vmax=5,
-                              title=obsid, xlabel='Frequency (Mhz)', ylabel='Time (UTC)')
+        #write plots if command flagged to do so
+        if args.plots:
+            Catalog_Plot.INS_plot(ins, flagged_prefix, xticks=xticks, yticks=yticks,
+                                  xticklabels=xticklabels, yticklabels=yticklabels,
+                                  data_cmap=cm.plasma, ms_vmin=-5, ms_vmax=5,
+                                  title=obsid, xlabel='Frequency (Mhz)', ylabel='Time (UTC)')
+
+            if args.verbose:
+                print("wrote trimmed zeromask (w/ match filter) for "+obsid)
+
+        #a hardcoded csv generator for occ_csv
+        if args.gencsv:
+            csv = ""+obsid+","+flagged_prefix+"_SSINS_data.h5,"+flagged_prefix+"_SSINS_mask.h5,"+flagged_prefix+"_SSINS_match_events.yml\n"
+            f.write(csv)
+            print("wrote entry for "+obsid)
+            print(csv)
+
+    #print out full length of run
+    if args.verbose:
+        print(f'Time taken: {time() - start}')


### PR DESCRIPTION
This PR adds three settings to the script, two of which are mostly conveniences and the third of which is topical to the `occ_csv.py` script.

* `-v --verbose` toggles conout of completed files and the total time elapsed once finished
* `-p --plots` toggles generation of plots (which cause a ~10x slowdown in total completion time)
* `-g --gencsv` toggles generation of a csv file `occcsv.csv` for occ_csv.py; if a file exists there it is wiped automatically 

Also, the description for -w is substantially changed since plots are seperate option now.