### PR TITLE
Diff def false

### DIFF
--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -7,6 +7,7 @@ import numpy as np
 from pyuvdata import UVData
 import scipy.stats
 import warnings
+import traceback
 
 
 class SS(UVData):
@@ -25,7 +26,7 @@ class SS(UVData):
         """Array of length Nfreqs that stores maximum likelihood estimators for
         each frequency, calculated using the MLE_calc method"""
 
-    def read(self, filename, diff=True, flag_choice=None, INS=None, custom=None,
+    def read(self, filename, diff=False, flag_choice=None, INS=None, custom=None,
              **kwargs):
 
         """
@@ -43,9 +44,17 @@ class SS(UVData):
         """
 
         super().read(filename, **kwargs)
-        if (self.data_array is not None) and diff:
-            self.diff()
-            self.apply_flags(flag_choice=flag_choice)
+
+        if (self.data_array is not None):
+            if diff:
+                self.diff()
+                self.apply_flags(flag_choice=flag_choice)
+            else:
+                # This warning will be issued when diff is False and there is some data read in
+                # If filename is a list of files, then this warning will get issued in the recursive call in UVData.read
+                warnings.warn("diff on read defaults to False now. Please double"
+                              " check SS.read call and ensure the appropriate"
+                              " keyword arguments for your intended use case.")
 
     def apply_flags(self, flag_choice=None, INS=None, custom=None):
         """

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -13,7 +13,7 @@ def test_init():
     file_type = 'uvfits'
 
     ss = SS()
-    ss.read(testfile, flag_choice='original')
+    ss.read(testfile, flag_choice='original', diff=True)
 
     ins = INS(ss)
 
@@ -37,7 +37,7 @@ def test_mean_subtract():
     file_type = 'uvfits'
 
     ss = SS()
-    ss.read(testfile)
+    ss.read(testfile, diff=True)
 
     ins = INS(ss, order=0)
 
@@ -60,7 +60,7 @@ def test_polyfit():
     file_type = 'uvfits'
 
     ss = SS()
-    ss.read(testfile)
+    ss.read(testfile, diff=True)
 
     ins = INS(ss, order=1)
 
@@ -91,7 +91,7 @@ def test_mask_to_flags():
     flags_outfile = '%s_SSINS_flags.h5' % prefix
 
     ss = SS()
-    ss.read(testfile)
+    ss.read(testfile, diff=True)
 
     uvd = UVData()
     uvd.read(testfile)
@@ -168,7 +168,7 @@ def test_write():
     sep_data_outfile = '%s.SSINS.data.h5' % prefix
 
     ss = SS()
-    ss.read(testfile, flag_choice='original')
+    ss.read(testfile, flag_choice='original', diff=True)
 
     ins = INS(ss)
     # Mock some events

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -22,7 +22,7 @@ def test_SS_read():
     assert ss.data_array is None, "Data array is not None"
 
     # Test select on read and diff
-    ss.read(testfile, times=np.unique(ss.time_array)[1:10])
+    ss.read(testfile, times=np.unique(ss.time_array)[1:10], diff=True)
     assert ss.Ntimes == 8, "Diff seems like it wasn't executed correctly"
 
     # See that it still passes UVData check
@@ -37,7 +37,7 @@ def test_apply_flags():
     insfile = os.path.join(DATA_PATH, '%s_SSINS.h5' % obs)
     ss = SS()
 
-    ss.read(testfile)
+    ss.read(testfile, diff=True)
 
     # Make sure no flags are applied to start with
     assert not np.any(ss.data_array.mask), "There are some flags to start with."
@@ -83,7 +83,7 @@ def test_mixture_prob():
     file_type = 'uvfits'
 
     ss = SS()
-    ss.read(testfile)
+    ss.read(testfile, diff=True)
     ss.apply_flags('original')
 
     # Generate the mixture probabilities
@@ -100,7 +100,7 @@ def test_rev_ind():
     file_type = 'uvfits'
 
     ss = SS()
-    ss.read(testfile)
+    ss.read(testfile, diff=True)
 
     # Make a band that will pick out only the largest value in the data
     dat_sort = np.sort(np.abs(ss.data_array), axis=None)
@@ -131,7 +131,7 @@ def test_write():
     outfile = os.path.join(DATA_PATH, 'test_write.uvfits')
 
     ss = SS()
-    ss.read(testfile)
+    ss.read(testfile, diff=True)
 
     custom = np.zeros_like(ss.data_array.mask)
     custom[:ss.Nbls] = 1

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -183,9 +183,6 @@ def test_read_multifiles():
                                           " keyword arguments for your intended use case.")):
         ss_orig.read(testfile, diff=False)
         ss_orig.diff()
-    with pytest.warns(UserWarning, match=("diff on read defaults to False now. Please double"
-                                          " check SS.read call and ensure the appropriate"
-                                          " keyword arguments for your intended use case.")):
         ss_multi.read(flist, diff=True)
 
     assert np.all(np.isclose(ss_orig.data_array, ss_multi.data_array)), "Diffs were different!"

--- a/SSINS/tests/test_plot.py
+++ b/SSINS/tests/test_plot.py
@@ -88,7 +88,7 @@ def test_VDH_plot():
     dens_outfile = '%s_VDH.pdf' % dens_prefix
 
     ss = SS()
-    ss.read(testfile, flag_choice='original')
+    ss.read(testfile, flag_choice='original', diff=True)
 
     cp.VDH_plot(ss, prefix)
     # Test with density prefix and error bars
@@ -110,7 +110,7 @@ def test_VDH_no_model():
     outfile = '%s_VDH.pdf' % prefix
 
     ss = SS()
-    ss.read(testfile, flag_choice=None)
+    ss.read(testfile, flag_choice=None, diff=True)
 
     with pytest.warns(UserWarning, match="Asking to plot post-flagging data, but SS.flag_choice is None. This is identical to plotting pre-flagging data"):
         cp.VDH_plot(ss, prefix, pre_model=False, post_model=False)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -27,9 +27,8 @@ Generating the sky-subtracted visibilities
 
   >>> # Read data by specifying a filepath as an argument to the read method
   >>> filepath = 'SSINS/data/1061313128_99bl_1pol_half_time.uvfits'
-  >>> # By default, the visibilities are differenced in time on read (see paper)
-  >>> ss.read(filepath)
-  >>> # Setting diff=False saves the differencing for later (not useful in most situations)
+  >>> # By default, the visibilities are NOT differenced in time on read (see paper). This is for compatibility with multi-file reading.
+  >>> ss.read(filepath, diff=True)
 
 (b) Passing keyword arguments to SS.read
 ****************************************
@@ -44,7 +43,7 @@ Generating the sky-subtracted visibilities
   >>> # The following lines make use of the time_array attribute (metadata) to
   >>> # read in all but the first and last integrations
   >>> times = np.unique(ss.time_array)[1:-1]
-  >>> ss.read(filepath, read_data=True, times=times)
+  >>> ss.read(filepath, read_data=True, times=times, diff=True)
 
 (c) Applying flags
 ******************


### PR DESCRIPTION
This change sets the default behavior of `diff` to `False` in `SS.read`. It issues a warning for cases where this is relevant. Unit tests to check diff'd data have been added. This was causing a bug when multiple files were being read in simultaneously, since `UVData.read` calls itself recursively in that case, and `SS.read` overrides `UVData.read`. This was leading to the first set of integrations begin differenced _twice_.