### PR TITLE
Mask when essential

### DIFF
--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -56,8 +56,10 @@ class INS(UVFlag):
 
         if self.type == 'baseline':
 
-            """Type of visibilities used in spectrum. Either cross or auto. No mixing allowed."""
             self.history += spec_type_str
+            # Check if the data has a mask yet. If not, mask it and set flag_choice to None.
+            if not isinstance(input.data_array, np.ma.MaskedArray):
+                input.apply_flags()
 
             self.metric_array = np.abs(input.data_array)
             """The baseline-averaged sky-subtracted visibility amplitudes (numpy masked array)"""

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -42,6 +42,8 @@ class SS(UVData):
             custom: A custom flag array for apply_flags()
             kwargs: Additional kwargs are passed to UVData.read()
         """
+        warnings.warn("SS.read will be renamed to SS.read_data soon to avoid"
+                      " conflicts with UVData.read.", category=PendingDeprecationWarning)
 
         super().read(filename, **kwargs)
 
@@ -55,6 +57,9 @@ class SS(UVData):
                 warnings.warn("diff on read defaults to False now. Please double"
                               " check SS.read call and ensure the appropriate"
                               " keyword arguments for your intended use case.")
+                if flag_choice is not None:
+                    warnings.warn("flag_choice will be ignored on read since"
+                                  " diff is being skipped.")
 
     def apply_flags(self, flag_choice=None, INS=None, custom=None):
         """

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -88,8 +88,10 @@ class SS(UVData):
             self.data_array.mask[:] = False
             for time_ind, time in enumerate(INS.time_array):
                 freq_inds, pol_inds = np.where(INS.metric_array.mask[time_ind])
-                blt_inds = np.where(self.time_array == time)
-                self.data_array.mask[blt_inds, :, freq_inds, pol_inds] = True
+                # Skip if nothing to flag
+                if len(freq_inds) > 0:
+                    blt_inds = np.where(self.time_array == time)
+                    self.data_array.mask[blt_inds, :, freq_inds, pol_inds] = True
         elif flag_choice is 'custom':
             self.data_array.mask[:] = False
             if custom is not None:

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -71,6 +71,8 @@ class SS(UVData):
             INS: An INS from which to apply flags - only used if flag_choice='INS'
             custom: A custom flag array from which to apply flags - only used if flag_choice='custom'
         """
+        if not isinstance(self.data_array, np.ma.MaskedArray):
+            self.data_array = np.ma.masked_array(self.data_array)
         self.flag_choice = flag_choice
         self.MLE = None
         if flag_choice is 'original':

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -193,6 +193,8 @@ class SS(UVData):
             prob: The probability to land in each bin based on the maximum likelihood model
         """
 
+        if not isinstance(self.data_array, np.ma.MaskedArray):
+            self.apply_flags()
         if self.MLE is None:
             self.MLE_calc()
         if bins is 'auto':
@@ -235,6 +237,8 @@ class SS(UVData):
 
         """
 
+        if not isinstance(self.data_array, np.ma.MaskedArray):
+            self.apply_flags()
         where_band = np.logical_and(np.absolute(self.data_array) > min(band),
                                     np.absolute(self.data_array) < max(band))
         where_band_mask = np.logical_and(np.logical_not(self.data_array.mask),

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -83,11 +83,13 @@ class SS(UVData):
         if flag_choice is 'original':
             self.data_array.mask = np.copy(self.flag_array)
         elif flag_choice is 'INS':
+            if not np.all(INS.time_array == np.unique(self.time_array)):
+                raise ValueError("INS object and SS object have incompatible time arrays. Cannot apply flags.")
             self.data_array.mask[:] = False
-            ind = np.where(INS.metric_array.mask)
-            for i in range(len(ind[0])):
-                self.data_array[ind[0][i] * self.Nbls:(ind[0][i] + 1) * self.Nbls,
-                                :, ind[1][i], ind[2][i]] = np.ma.masked
+            for time_ind, time in enumerate(INS.time_array):
+                freq_inds, pol_inds = np.where(INS.metric_array.mask[time_ind])
+                blt_inds = np.where(self.time_array == time)
+                self.data_array.mask[blt_inds, :, freq_inds, pol_inds] = True
         elif flag_choice is 'custom':
             self.data_array.mask[:] = False
             if custom is not None:

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -33,6 +33,20 @@ def test_init():
     assert np.all(test_weights == ins.weights_array), "Weights did not sum properly"
 
 
+def test_no_diff_start():
+    obs = '1061313128_99bl_1pol_half_time'
+    testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)
+    file_type = 'uvfits'
+
+    # Don't diff - will fail to mask data array
+    ss = SS()
+    ss.read(testfile, flag_choice='original', diff=False)
+
+    ins = INS(ss)
+
+    assert ss.flag_choice is None
+
+
 def test_mean_subtract():
 
     obs = '1061313128_99bl_1pol_half_time'

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -102,6 +102,11 @@ def test_apply_flags():
     assert not np.any(ss.data_array.mask[:, :, [0] + list(range(2, ss.Nfreqs)), :]), "Channels were flagged that should not have been."
     assert ss.flag_choice is 'INS'
 
+    # Make a bad time array to test an error
+    ins.time_array = ins.time_array + 1
+    with pytest.raises(ValueError):
+        ss.apply_flags(flag_choice='INS', INS=ins)
+
     # Make flag_choice custom but do not provide array - should unflag everything and issue a warning
     with pytest.warns(UserWarning, match="Custom flags were chosen, but custom flags were None type. Setting flag_choice to None and unmasking data."):
         ss.apply_flags(flag_choice='custom', custom=None)

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -133,6 +133,14 @@ def test_mixture_prob():
     # Check that they sum to close to 1
     assert np.isclose(np.sum(mixture_prob), 1), "Probabilities did not add up to close to 1"
 
+    # Do a new read, but don't diff. Run and check mask.
+    ss = SS()
+    ss.read(testfile, diff=False)
+
+    mixture_prob = ss.mixture_prob(bins='auto')
+
+    assert ss.flag_choice is None
+
 
 def test_rev_ind():
 
@@ -162,6 +170,14 @@ def test_rev_ind():
 
     # Check no other points were picked up
     assert np.count_nonzero(wf_hist) == 1, "The algorithm found other data"
+
+    # Do a new read, but don't diff. Run and check mask.
+    ss = SS()
+    ss.read(testfile, diff=False)
+
+    rev_ind_hist = ss.rev_ind(band)
+
+    assert ss.flag_choice is None
 
 
 def test_write():

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -93,12 +93,13 @@ def test_apply_flags():
     assert np.all(ss.data_array.mask), "The custom flag array was not applied"
     assert ss.flag_choice is 'custom', "The flag choice attribute was not changed"
 
-    # Read an INS in (no flags by default) and flag a channel, test if it applies correctly
+    # Read an INS in (no flags by default) and flag a channel for two times stuff, see if applied correctly
     ins = INS(insfile)
-    ins.metric_array.mask[:, 0] = True
+    ins.metric_array.mask[[2, 4], 1, :] = True
     ss.apply_flags(flag_choice='INS', INS=ins)
-    assert np.all(ss.data_array.mask[:, 0, 0]), "Not all of the 0th channel was flagged."
-    assert not np.any(ss.data_array.mask[:, 0, 1:]), "Some of the channels other than the 0th were flagged"
+    assert np.all(ss.data_array.mask[2::ss.Ntimes, :, 1, :]), "The 2nd time was not flagged."
+    assert np.all(ss.data_array.mask[4::ss.Ntimes, :, 1, :]), "The 4th time was not flagged."
+    assert not np.any(ss.data_array.mask[:, :, [0] + list(range(2, ss.Nfreqs)), :]), "Channels were flagged that should not have been."
     assert ss.flag_choice is 'INS'
 
     # Make flag_choice custom but do not provide array - should unflag everything and issue a warning

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -225,3 +225,20 @@ def test_read_multifiles():
 
     for path in flist:
         os.remove(path)
+
+
+def test_newmask():
+
+    obs = '1061313128_99bl_1pol_half_time'
+    testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)
+    file_type = 'uvfits'
+
+    ss = SS()
+    ss.read(testfile, diff=False)
+
+    assert not isinstance(ss.data_array, np.ma.MaskedArray)
+
+    ss.apply_flags()
+
+    assert ss.flag_choice is None
+    assert isinstance(ss.data_array, np.ma.MaskedArray)

--- a/scripts/Run_HERA_SSINS.py
+++ b/scripts/Run_HERA_SSINS.py
@@ -30,11 +30,7 @@ version_hist_substr = reduce(lambda x, y: x + y, version_info_list)
 
 # Make the SS object
 ss = SS()
-ss.read(args.filename, ant_str='cross', diff=False)
-if args.no_diff:
-    ss.diff()
-else:
-    ss.data_array = np.ma.masked_array(ss.data_array)
+ss.read(args.filename, ant_str='cross', diff=args.no_diff)
 
 # Make the INS object
 ins = INS(ss)
@@ -72,5 +68,7 @@ ins.history += "Flagged using apply_match_test on SSINS %s." % version_hist_subs
 # Write outputs
 ins.write(args.prefix, output_type='mask', sep='.', clobber=args.clobber)
 uvf.history += ins.history
-ins.write(args.prefix, output_type='flags', sep='.', uvf=uvf, clobber=args.clobber)
+# "flags" are not helpful if no differencing was done
+if args.no_diff:
+    ins.write(args.prefix, output_type='flags', sep='.', uvf=uvf, clobber=args.clobber)
 ins.write(args.prefix, output_type='match_events', sep='.', clobber=args.clobber)


### PR DESCRIPTION
This small PR just ensures that the SS data array is masked when necessary. Previously, if diff() was not called on read, the data_array would not get masked and issues would happen when initializing INS objects. Now, there is a quick check on initialization and an application of a mask if one is missing.