### PR TITLE
Weighted Incoherent Average

### DIFF
--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -97,7 +97,7 @@ class INS(UVFlag):
                                   " crosses before averaging.")
                     self.select(blt_inds=np.where(auto_bool)[0])
 
-            super().to_waterfall(method='mean')
+            super().to_waterfall(method='mean', return_weights_square=use_integration_weights)
         # Make sure the right type of spectrum is being used, otherwise raise errors.
         # If neither statement inside is true, then it is an old spectrum and is therefore a cross-only spectrum.
         elif spec_type_str not in self.history:

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -97,7 +97,7 @@ class INS(UVFlag):
                                   " crosses before averaging.")
                     self.select(blt_inds=np.where(auto_bool)[0])
 
-            super().to_waterfall(method='mean', return_weights_square=use_integration_weights)
+            super().to_waterfall(method='mean', return_weights_square=True)
         # Make sure the right type of spectrum is being used, otherwise raise errors.
         # If neither statement inside is true, then it is an old spectrum and is therefore a cross-only spectrum.
         elif spec_type_str not in self.history:
@@ -162,8 +162,9 @@ class INS(UVFlag):
             C = np.array([C_pol_map[pol] for pol in self.polarization_array])
 
         if not self.order:
-            coeffs = self.metric_array[:, freq_slice].mean(axis=0)
-            MS = (self.metric_array[:, freq_slice] / coeffs - 1) * np.sqrt(self.weights_array[:, freq_slice] / C)
+            coeffs = self.metric_array[:, freq_slice].average(axis=0, weights=self.weights_array)
+            weights_factor = self.weights_array[:, freq_slice] / np.sqrt(C * self.weights_square_array[:, freq_slice])
+            MS = (self.metric_array[:, freq_slice] / coeffs - 1) * weights_factor
         else:
             MS = np.zeros_like(self.metric_array[:, freq_slice])
             coeffs = np.zeros((self.order + 1, ) + MS.shape[1:])

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -19,7 +19,8 @@ class INS(UVFlag):
     """
 
     def __init__(self, input, history='', label='', order=0, mask_file=None,
-                 match_events_file=None, spectrum_type="cross"):
+                 match_events_file=None, spectrum_type="cross",
+                 use_integration_weights=False):
 
         """
         init function for the INS class.
@@ -32,6 +33,7 @@ class INS(UVFlag):
             mask_file: A path to an .h5 (UVFlag) file that contains a mask for the metric_array
             match_events_file: A path to a .yml file that has events caught by the match filter
             spectrum_type: Type of visibilities to use in making the specturm. Options are 'auto' or 'cross'.
+            use_integration_weights: Whether to use the integration time and nsample array to compute the weights
         """
 
         super().__init__(input, mode='metric', copy_flags=False,
@@ -65,6 +67,8 @@ class INS(UVFlag):
             """The baseline-averaged sky-subtracted visibility amplitudes (numpy masked array)"""
             self.weights_array = np.logical_not(input.data_array.mask).astype(float)
             """The number of baselines that contributed to each element of the metric_array"""
+            if use_integration_weights:
+                self.weights_array *= input.nsample_array * input.integration_time
 
             cross_bool = self.ant_1_array != self.ant_2_array
             auto_bool = self.ant_1_array == self.ant_2_array

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -132,6 +132,10 @@ class INS(UVFlag):
         else:
             self.match_events = self.match_events_read(match_events_file)
 
+        # For backwards compatibilty before weights_square_array was a thing
+        # Works because weights are all 1 or 0 before this feature was added
+        if self.weights_square_array is None:
+            self.weights_square_array = self.weights_array
         self.metric_ms = self.mean_subtract()
         """An array containing the z-scores of the data in the incoherent noise spectrum."""
         self.sig_array = np.ma.copy(self.metric_ms)

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -34,6 +34,11 @@ class INS(UVFlag):
             match_events_file: A path to a .yml file that has events caught by the match filter
             spectrum_type: Type of visibilities to use in making the specturm. Options are 'auto' or 'cross'.
             use_integration_weights: Whether to use the integration time and nsample array to compute the weights
+            nsample_default: The default nsample value to fill zeros in the
+                nsample_array with when there are some nsample=0. Important when
+                working with data from uvfits files, which combine information
+                from the flag_array and nsample_array in the weights field of
+                the uvfits file.
         """
 
         super().__init__(input, mode='metric', copy_flags=False,

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -189,13 +189,16 @@ class INS(UVFlag):
                         # Channels which share a mask (indexed into good_chans)
                         chans = np.where(mask_inv == mask_ind)[0]
                         y = good_data[:, chans]
-                        coeff = np.ma.polyfit(x, y, self.order)
+                        w = self.weights_array[:, freq_slice, pol_ind][:, good_chans[chans]]
+                        w_sq = self.weights_square_array[:, freq_slice, pol_ind][:, good_chans[chans]]
+                        coeff = np.ma.polyfit(x, y, self.order, w=w)
                         coeffs[:, good_chans[chans], pol_ind] = coeff
                         # Make the fit spectrum
                         mu = np.sum([np.outer(x**(self.order - poly_ind), coeff[poly_ind])
                                      for poly_ind in range(self.order + 1)],
                                     axis=0)
-                        MS[:, good_chans[chans], pol_ind] = (y / mu - 1) * np.sqrt(self.weights_array[:, freq_slice, pol_ind][:, good_chans[chans]] / C)
+                        weights_factor = w / np.sqrt(C * w_sq)
+                        MS[:, good_chans[chans], pol_ind] = (y / mu - 1) * weights_factor
             else:
                 MS[:] = np.ma.masked
 

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -93,8 +93,6 @@ def test_polyfit():
     test_coeffs = np.zeros((ins.order + 1, ) + ins.metric_ms.shape[1:])
     test_coeffs[0, :] = 3
     test_coeffs[1, :] = 5
-    print(np.amin(ins.metric_ms))
-    print(np.amax(ins.metric_ms))
 
     assert np.all(np.allclose(ins.metric_ms, np.zeros(ins.metric_ms.shape))), "The polyfit was not exact"
     assert np.all(np.allclose(coeffs, test_coeffs)), "The polyfit got the wrong coefficients"
@@ -294,8 +292,10 @@ def test_data_params():
     obs = '1061313128_99bl_1pol_half_time_SSINS'
     testfile = os.path.join(DATA_PATH, '%s.h5' % obs)
     ins = INS(testfile)
+    test_params = ['metric_array', 'weights_array', 'weights_square_array',
+                   'metric_ms', 'sig_array']
 
-    assert ins._data_params == ['metric_array', 'weights_array', 'metric_ms', 'sig_array']
+    assert ins._data_params == test_params
 
 
 def test_spectrum_type_file_init():

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -371,3 +371,19 @@ def test_mix_spectrum():
     ss.polarization_array[0] = 1
     with pytest.raises(ValueError, match="SS input has pseudo-Stokes data. SSINS does not"):
         ins = INS(ss, spectrum_type="auto")
+
+
+def test_use_integration_weights():
+
+    obs = '1061313128_99bl_1pol_half_time'
+    testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)
+    file_type = 'uvfits'
+
+    ss = SS()
+    ss.read(testfile, flag_choice='original', diff=True)
+
+    ins = INS(ss, use_integration_weights=True)
+
+    # These will not be equal if weights are not binary to begin with
+    # The accuracy of return_weights_square is already checked in pyuvdata
+    assert not np.all(ins.weights_array == ins.weights_square_array)

--- a/SSINS/tests/test_MF.py
+++ b/SSINS/tests/test_MF.py
@@ -55,13 +55,13 @@ def test_match_test():
     ins = INS(insfile)
 
     # Mock a simple metric_array and freq_array
-    ins.metric_array = np.ma.ones([10, 20, 1])
+    ins.metric_array[:] = np.ones_like(ins.metric_array)
     ins.weights_array = np.copy(ins.metric_array)
-    ins.freq_array = np.zeros([1, 20])
-    ins.freq_array = np.arange(20)
+    ins.weights_square_array = np.copy(ins.weights_array)
 
     # Make a shape dictionary for a shape that will be injected later
-    shape = [7.9, 12.1]
+    ch_wid = ins.freq_array[1] - ins.freq_array[0]
+    shape = [ins.freq_array[8] - 0.2 * ch_wid, ins.freq_array[12] + 0.2 * ch_wid]
     shape_dict = {'shape': shape}
     sig_thresh = {'shape': 5, 'narrow': 5, 'streak': 5}
     mf = MF(ins.freq_array, sig_thresh, shape_dict=shape_dict)
@@ -73,10 +73,9 @@ def test_match_test():
     ins.metric_ms = ins.mean_subtract()
 
     t_max, f_max, R_max, shape_max = mf.match_test(ins)
-    print(shape_max)
 
     assert t_max == slice(5, 6), "Wrong time"
-    assert f_max == slice(0, 20), "Wrong freq"
+    assert f_max == slice(0, ins.Nfreqs), "Wrong freq"
     assert shape_max == 'streak', "Wrong shape"
 
 
@@ -88,13 +87,13 @@ def test_apply_match_test():
     ins = INS(insfile)
 
     # Mock a simple metric_array and freq_array
-    ins.metric_array = np.ma.ones([10, 20, 1])
+    ins.metric_array[:] = np.ones_like(ins.metric_array)
     ins.weights_array = np.copy(ins.metric_array)
-    ins.freq_array = np.zeros([1, 20])
-    ins.freq_array = np.arange(20)
+    ins.weights_square_array = np.copy(ins.weights_array)
 
     # Make a shape dictionary for a shape that will be injected later
-    shape = [7.9, 12.1]
+    ch_wid = ins.freq_array[1] - ins.freq_array[0]
+    shape = [ins.freq_array[8] - 0.2 * ch_wid, ins.freq_array[12] + 0.2 * ch_wid]
     shape_dict = {'shape': shape}
     sig_thresh = {'shape': 5, 'narrow': 5, 'streak': 5}
     mf = MF(ins.freq_array, sig_thresh, shape_dict=shape_dict)
@@ -116,12 +115,12 @@ def test_apply_match_test():
 
     assert np.all(test_mask == ins.metric_array.mask), "Flags are incorrect"
 
-    test_match_events_slc = [(slice(5, 6), slice(0, 20), 'streak'),
+    test_match_events_slc = [(slice(5, 6), slice(0, ins.Nfreqs), 'streak'),
                              (slice(7, 8), slice(7, 13), 'shape'),
                              (slice(3, 4), slice(5, 6), 'narrow')]
 
     for i, event in enumerate(test_match_events_slc):
-        assert ins.match_events[i][:-1] == test_match_events_slc[i], "%ith event is wrong" % i
+        assert ins.match_events[i][:-1] == test_match_events_slc[i], f"{i}th event is wrong"
 
     assert not np.any([ins.match_events[i][-1] < 5 for i in range(3)]), "Some significances were less than 5"
 
@@ -146,6 +145,7 @@ def test_time_broadcast():
     # Mock a simple metric_array and freq_array
     ins.metric_array[:] = 1
     ins.weights_array = np.copy(ins.metric_array)
+    ins.weights_square_array = np.copy(ins.weights_array)
     ins.metric_ms = ins.mean_subtract()
     ins.sig_array = np.ma.copy(ins.metric_ms)
 

--- a/SSINS/tests/test_MF.py
+++ b/SSINS/tests/test_MF.py
@@ -198,9 +198,10 @@ def test_time_broadcast_no_new_event():
 
     ins = INS(insfile)
 
-    # Mock a simple metric_array and freq_array
+    # Mock a simple metric_array and freq_array (and weights...)
     ins.metric_array[:] = 1
     ins.weights_array = np.copy(ins.metric_array)
+    ins.weights_square_array = np.copy(ins.weights_array)
     ins.metric_ms = ins.mean_subtract()
     ins.sig_array = np.ma.copy(ins.metric_ms)
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -371,9 +371,10 @@ Extra Flagging Bits
   >>> # This means events found at the very edge of one subbands may induce flags in the other, unless a guard band is thrown in
   >>> # An example 100 kHz guard band program might look like this
   >>> guard_width = 100e3
-  >>> broadcast_dict = {'TV4': [174e6, 182e6 - guard_width],
-  >>>                   'guard_4_5': [182e6 - guard_width, 182e6 + guard_width],
-  >>>                   'TV5': [182e6 + guard_width, 190e6 - guard_width]}
+  >>> broadcast_dict = {}
+  >>> broadcast_dict['TV4'] = [174e6, 182e6 - guard_width]
+  >>> broadcast_dict['guard_4_5'] = [182e6 - guard_width, 182e6 + guard_width]
+  >>> broadcast_dict['TV5'] = [182e6 + guard_width, 190e6 - guard_width]
   >>> mf = MF(ins.freq_array, 5, broadcast_dict=broadcast_dict)
 
 


### PR DESCRIPTION
This PR let's SSINS use the nsample_array and integration_time attributes of an SS (UVData) object in order to do a weighted incoherent average, with the correct z-scores.