### PR TITLE
Add Combining INS of different baseline subsets

### DIFF
--- a/SSINS/util.py
+++ b/SSINS/util.py
@@ -5,6 +5,8 @@ useful for scripts.
 import numpy as np
 import os
 from SSINS.match_filter import Event
+import copy
+import warnings
 
 
 def event_count(event_list, time_range, freq_range=None):
@@ -89,7 +91,7 @@ def calc_occ(ins, mf, num_init_flag, num_int_flag=0, lump_narrowband=False):
 
 
 def make_obslist(obsfile):
-    #due to the newline character, raw string is needed `r"""`
+    # due to the newline character, raw string is needed `r"""`
     r"""
     Makes a python list from a text file whose lines are separated by "\\n"
 
@@ -135,3 +137,48 @@ def make_ticks_labels(freqs, freq_array, sig_fig=1):
     labels = [('%.' + str(sig_fig) + 'f') % (10**-6 * freq) for freq in freqs]
 
     return(ticks, labels)
+
+
+def combine_ins(ins1, ins2, inplace=True):
+    """
+    This utility function combines INS for the same obs that have been averaged
+    over different baselines.
+
+    Args:
+        ins1: The first spectrum for the combination
+        ins2: The second spectrum for the combination
+        inplace: Whether to do the operation inplace on ins1 or not.
+    """
+
+    if not np.array_equal(ins1.time_array, ins2.time_array):
+        raise ValueError("The spectra do not have matching time arrays.")
+
+    if not np.array_equal(ins1.freq_array, ins2.freq_array):
+        raise ValueError("The spectra do not have the same frequencies.")
+
+    if not np.array_equal(ins1.polarization_array, ins2.polarization_array):
+        raise ValueErrpr("The spectra do not have the same pols.")
+
+    if not ins1.spectrum_type == ins2.spectrum_type:
+        raise ValueError(f"ins1 is of type {ins1.spectrum_type} while ins2 is of type {ins2.spectrum_type}")
+
+    if (not np.array_equal(ins1.metric_ms, ins1.sig_array)) or (not np.array_equal(ins2.metric_ms, ins2.sig_array)):
+        warnings.warn("sig_array attribute will be reset after combinging INS")
+
+    if inplace:
+        this = ins1
+    else:
+        this = copy.deepcopy(ins1)
+
+    new_weights = this.weights_array + ins2.weights_array
+    new_weights_square = this.weights_square_array + ins2.weights_square_array
+    new_metric = (this.weights_array * this.metric_array + ins2.weights_array * ins2.metric_array) / new_weights
+
+    this.metric_array = new_metric
+    this.weights_array = new_weights
+    this.weights_square_array = new_weights_square
+
+    this.metric_ms = this.mean_subtract()
+    this.sig_array = np.ma.copy(this.metric_ms)
+
+    return(this)

--- a/SSINS/util.py
+++ b/SSINS/util.py
@@ -139,7 +139,7 @@ def make_ticks_labels(freqs, freq_array, sig_fig=1):
     return(ticks, labels)
 
 
-def combine_ins(ins1, ins2, inplace=True):
+def combine_ins(ins1, ins2, inplace=False):
     """
     This utility function combines INS for the same obs that have been averaged
     over different baselines.
@@ -157,7 +157,7 @@ def combine_ins(ins1, ins2, inplace=True):
         raise ValueError("The spectra do not have the same frequencies.")
 
     if not np.array_equal(ins1.polarization_array, ins2.polarization_array):
-        raise ValueErrpr("The spectra do not have the same pols.")
+        raise ValueError("The spectra do not have the same pols.")
 
     if not ins1.spectrum_type == ins2.spectrum_type:
         raise ValueError(f"ins1 is of type {ins1.spectrum_type} while ins2 is of type {ins2.spectrum_type}")

--- a/scripts/Run_HERA_SSINS.py
+++ b/scripts/Run_HERA_SSINS.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-from SSINS import SS, INS, version, MF
+from SSINS import SS, INS, version, MF, util
 from SSINS.data import DATA_PATH
 from functools import reduce
 import numpy as np
@@ -40,14 +40,13 @@ del uvd
 # Make the SS object
 ss = SS()
 if args.num_baselines > 0:
-    ss.read(args.filename, ant_str='cross', bls=bls[:args.num_baselines],
+    ss.read(args.filename, bls=bls[:args.num_baselines],
             diff=args.no_diff)
     ins = INS(ss)
     Nbls = len(bls)
     for slice_ind in range(args.num_baselines, Nbls, args.num_baselines):
         ss = SS()
-        ss.read(args.filename, ant_str='cross',
-                bls=bls[slice_ind:slice_ind + args.num_baselines],
+        ss.read(args.filename, bls=bls[slice_ind:slice_ind + args.num_baselines],
                 diff=args.no_diff)
         new_ins = INS(ss)
         ins = util.combine_ins(ins, new_ins)


### PR DESCRIPTION
This PR adds a utility function that allows for combining INS that have been calculated for different baseline subsets within an observation. Since an INS has no exact concept of which baselines actually contributed, only the number that contributed to each sample, there is no check to confirm that different baseline subsets being combined are actually exclusive to one another. However, there are checks to make sure that the time, frequency, and polarization arrays match.