### PR TITLE
update travis os to ubuntu focal (20.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 os:
   - osx
   - linux
-dist: trusty
+dist: focal
 env:
   global:
     - COVERALLS_PARALLEL=true


### PR DESCRIPTION
Also see #68 which is somewhat related.

This change changes the OS keyword for Travis to do CI with from Ubuntu Trusty (14.04, April 2014) to Focal (20.04, April 2020); Ubuntu 14.04 is now out of date and no longer supported by Canonical.