### PR TITLE
Select inplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added match_filter writeout to yaml format.
 - Added extent options to plotting libraries so that default ticks on plots would
   be sensible and easy.
+- Added inplace keyword to select
 
 
 ## 1.4.4

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -490,7 +490,7 @@ class INS(UVFlag):
 
         ins.metric_array.mask = np.copy(mask_uvf.flag_array)
         # In case this is called in the middle of the constructor.
-        if hasattr(this, 'metric_ms'):
+        if hasattr(ins, 'metric_ms'):
             ins.metric_ms = this.mean_subtract()
 
         if not inplace:

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -473,24 +473,28 @@ class INS(UVFlag):
         immediately afterwards.
 
         args:
-            inplace: Whether to do the operation inplace or return a copy.
+            inplace: Whether to do the operation inplace or return a copy without
+                touching the original.
+
+        returns:
+            ins: INS object. Only returned if inplace is False.
         """
         if inplace:
-            this = self
+            ins = self
         else:
-            this = self.copy()
+            ins = self.copy()
 
-        mask_uvf = this._make_mask_copy()
-        super(INS, this).select(inplace=True, **kwargs)
+        mask_uvf = ins._make_mask_copy()
+        super(INS, ins).select(inplace=True, **kwargs)
         super(INS, mask_uvf).select(inplace=True, **kwargs)
 
         this.metric_array.mask = np.copy(mask_uvf.flag_array)
         # In case this is called in the middle of the constructor.
         if hasattr(this, 'metric_ms'):
-            this.metric_ms = this.mean_subtract()
+            ins.metric_ms = this.mean_subtract()
 
         if not inplace:
-            return(this)
+            return(ins)
 
     def __add__(self, other, inplace=False, axis="time", run_check=True,
                 check_extra=True, run_check_acceptability=True):

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -468,17 +468,29 @@ class INS(UVFlag):
             SSINS_params = UVFlag_params + Extra_params
         return(SSINS_params)
 
-    def select(self, **kwargs):
+    def select(self, inplace=True, **kwargs):
         """Thin wrapper around UVFlag.select that also recalculates the ms array
         immediately afterwards.
-        """
 
-        mask_uvf = self._make_mask_copy()
-        super(INS, self).select(**kwargs)
-        super(INS, mask_uvf).select(**kwargs)
-        self.metric_array.mask = np.copy(mask_uvf.flag_array)
-        if hasattr(self, 'metric_ms'):
-            self.metric_ms = self.mean_subtract()
+        args:
+            inplace: Whether to do the operation inplace or return a copy.
+        """
+        if inplace:
+            this = self
+        else:
+            this = self.copy()
+
+        mask_uvf = this._make_mask_copy()
+        super(INS, this).select(inplace=True, **kwargs)
+        super(INS, mask_uvf).select(inplace=True, **kwargs)
+
+        this.metric_array.mask = np.copy(mask_uvf.flag_array)
+        # In case this is called in the middle of the constructor.
+        if hasattr(this, 'metric_ms'):
+            this.metric_ms = this.mean_subtract()
+
+        if not inplace:
+            return(this)
 
     def __add__(self, other, inplace=False, axis="time", run_check=True,
                 check_extra=True, run_check_acceptability=True):

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -488,7 +488,7 @@ class INS(UVFlag):
         super(INS, ins).select(inplace=True, **kwargs)
         super(INS, mask_uvf).select(inplace=True, **kwargs)
 
-        this.metric_array.mask = np.copy(mask_uvf.flag_array)
+        ins.metric_array.mask = np.copy(mask_uvf.flag_array)
         # In case this is called in the middle of the constructor.
         if hasattr(this, 'metric_ms'):
             ins.metric_ms = this.mean_subtract()

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -491,7 +491,7 @@ class INS(UVFlag):
         ins.metric_array.mask = np.copy(mask_uvf.flag_array)
         # In case this is called in the middle of the constructor.
         if hasattr(ins, 'metric_ms'):
-            ins.metric_ms = this.mean_subtract()
+            ins.metric_ms = ins.mean_subtract()
 
         if not inplace:
             return(ins)

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -278,6 +278,9 @@ def test_select():
     ins = INS(testfile)
     ins.metric_array.mask[7, :12] = True
 
+    new_ins = ins.select(times=ins.time_array[3:-3], freq_chans=np.arange(24),
+                         inplace=False)
+
     Ntimes = len(ins.time_array)
     ins.select(times=ins.time_array[3:-3], freq_chans=np.arange(24))
 
@@ -288,6 +291,9 @@ def test_select():
     # Check that the mask is propagated
     assert np.all(ins.metric_array.mask[4, :12])
     assert np.count_nonzero(ins.metric_array.mask) == 12
+
+    # Check that new_ins is a copy of ins
+    assert new_ins == ins
 
 
 def test_data_params():


### PR DESCRIPTION
This PR gives a keyword `inplace` to select that when True does the select inplace on the INS object (default) or when False, returns a copy of the selected object without touching the original object.