### PR TITLE
import error hotfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from setuptools import setup
 import os
 import json
 
-from SSINS import version
+sys.path.append('SSINS')
+import version  # noqa
 
 # Make a GIT_INFO file on install
 data = [version.git_origin, version.git_hash, version.git_description, version.git_branch]

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from setuptools import setup
 import os
+import sys
 import json
 
 sys.path.append('SSINS')


### PR DESCRIPTION
Fixes error thrown by installation with yaml. Changes the way SSINS defines its version so that SSINS can be installed without importing all its requirements

The yaml lines below give an error message (also below). This would be fixed by switching to using `setuptools_scm`, but this hotfix takes care of the problem for now.

``` 
 - pip:
      - -e ./repos/pyuvdata
      - -e ./repos/SSINS
```


```
Collecting package metadata (repodata.json): done
Solving environment: done
Preparing transaction: done
Verifying transaction: done
Executing transaction: done
Installing pip dependencies: / Ran pip subprocess with arguments:
['/home/azureuser/miniconda3/envs/azure/bin/python', '-m', 'pip', 'install', '-U', '-r', '/home/azureuser/condaenv.z7fp8qls.requirements.txt']
Pip subprocess output:
Obtaining file:///home/azureuser/repos/SSINS (from -r /home/azureuser/condaenv.z7fp8qls.requirements.txt (line 1))Pip subprocess error:
    ERROR: Command errored out with exit status 1:
     command: /home/azureuser/miniconda3/envs/azure/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/azureuser/repos/SSINS/setup.py'"'"'; __file__='"'"'/home/azureuser/repos/SSINS/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-h7s1gzup
         cwd: /home/azureuser/repos/SSINS/
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/azureuser/repos/SSINS/setup.py", line 7, in <module>
        from SSINS import version
      File "/home/azureuser/repos/SSINS/SSINS/__init__.py", line 12, in <module>
        from .incoherent_noise_spectrum import *
      File "/home/azureuser/repos/SSINS/SSINS/incoherent_noise_spectrum.py", line 7, in <module>
        from pyuvdata import UVFlag
    ModuleNotFoundError: No module named 'pyuvdata'
    ----------------------------------------
WARNING: Discarding file:///home/azureuser/repos/SSINS. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.failedCondaEnvException: Pip failed
```