### PR TITLE
Warnings markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added extent options to plotting libraries so that default ticks on plots would
   be sensible and easy.
 - Added inplace keyword to select
-
+- Add warning filters to unit tests.
 
 ## 1.4.4
 

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -197,7 +197,7 @@ class SS(UVData):
             self.apply_flags()
         if self.MLE is None:
             self.MLE_calc()
-        if bins == 'auto':
+        if type(bins) == str:
             _, bins = np.histogram(np.abs(self.data_array[np.logical_not(self.data_array.mask)]))
 
         N_spec = np.sum(np.logical_not(self.data_array.mask), axis=(0, 1, -1))

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -7,6 +7,8 @@ from pyuvdata import UVData, UVFlag
 from datetime import datetime
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:invalid value",
+                            "ignore:SS.read")
 def test_init():
 
     obs = '1061313128_99bl_1pol_half_time'
@@ -41,13 +43,18 @@ def test_no_diff_start():
 
     # Don't diff - will fail to mask data array
     ss = SS()
-    ss.read(testfile, flag_choice='original', diff=False)
+    with pytest.warns(UserWarning, match="flag_choice will be ignored"):
+        ss.read(testfile, flag_choice='original', diff=False)
+
+    with pytest.warns(UserWarning, match="diff on read defaults to False"):
+        ss.read(testfile, flag_choice='original', diff=False)
 
     ins = INS(ss)
 
     assert ss.flag_choice is None
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read")
 def test_mean_subtract():
 
     obs = '1061313128_99bl_1pol_half_time'
@@ -71,6 +78,7 @@ def test_mean_subtract():
     assert not np.all(old_dat[1:, :5] == ins.metric_ms[1:, :5]), "All elements of the ms array are still equal"
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read")
 def test_polyfit():
 
     obs = '1061313128_99bl_1pol_half_time'
@@ -102,6 +110,7 @@ def test_polyfit():
     assert np.all(ins.metric_ms.mask), "The metric_ms array was not all masked"
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read")
 def test_mask_to_flags():
     obs = '1061313128_99bl_1pol_half_time'
     testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)
@@ -174,6 +183,7 @@ def test_mask_to_flags():
     os.remove(flags_outfile)
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read", "ignore:invalid value")
 def test_write():
 
     obs = '1061313128_99bl_1pol_half_time'
@@ -330,6 +340,7 @@ def test_spectrum_type_file_init():
     ins = INS(auto_testfile, spectrum_type="auto")
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read")
 def test_spectrum_type_bl_init():
     obs = '1061313128_99bl_1pol_half_time'
     testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
@@ -351,6 +362,7 @@ def test_spectrum_type_bad_input():
         ins = INS(testfile, spectrum_type="foo")
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read")
 def test_no_cross_auto_spectrum():
     obs = "1061312640_autos"
     testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
@@ -362,6 +374,7 @@ def test_no_cross_auto_spectrum():
         ins = INS(ss)
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read")
 def test_mix_spectrum():
     obs = "1061312640_mix"
     testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
@@ -381,6 +394,7 @@ def test_mix_spectrum():
         ins = INS(ss, spectrum_type="auto")
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read", "ignore:invalid value")
 def test_use_integration_weights():
 
     obs = '1061313128_99bl_1pol_half_time'

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -10,14 +10,16 @@ Tests the various capabilities of the sky_subtract class
 """
 
 
+@pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read")
 def test_SS_read():
     obs = '1061313128_99bl_1pol_half_time'
     testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)
 
     ss = SS()
 
-    # Test reading in only metadata skips if block
-    ss.read(testfile, read_data=False)
+    # Test reading in only metadata skips if block and warning
+    with pytest.warns(PendingDeprecationWarning, match="SS.read will be renamed"):
+        ss.read(testfile, read_data=False)
     assert ss.data_array is None, "Data array is not None"
 
     # Test select on read and diff
@@ -64,6 +66,7 @@ def test_diff():
     assert np.all(ss.ant_2_array == np.array([1, 2])), "ant_2_array disagrees!"
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")
 def test_apply_flags():
 
     obs = '1061313128_99bl_1pol_half_time'
@@ -117,6 +120,8 @@ def test_apply_flags():
         ss.apply_flags(flag_choice='bad_choice')
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering",
+                            "ignore:diff on read")
 def test_mixture_prob():
 
     obs = '1061313128_99bl_1pol_half_time'
@@ -142,6 +147,8 @@ def test_mixture_prob():
     assert ss.flag_choice is None
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering",
+                            "ignore:diff on read")
 def test_rev_ind():
 
     obs = '1061313128_99bl_1pol_half_time'
@@ -180,6 +187,8 @@ def test_rev_ind():
     assert ss.flag_choice is None
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering",
+                            "ignore:some nsamples", "ignore:elementwise")
 def test_write():
 
     obs = '1061313128_99bl_1pol_half_time'
@@ -260,6 +269,7 @@ def test_read_multifiles():
         os.remove(path)
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:diff on read")
 def test_newmask():
 
     obs = '1061313128_99bl_1pol_half_time'

--- a/SSINS/tests/test_plot.py
+++ b/SSINS/tests/test_plot.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 
+@pytest.mark.filterwarnings("ignore:default base")
 def test_INS_plot():
 
     matplotlib = pytest.importorskip("matplotlib")
@@ -35,8 +36,10 @@ def test_INS_plot():
     with pytest.warns(UserWarning, match="LSTs appear to cross"):
         cp.INS_plot(ins, prefix, backend='Agg', use_extent=True,
                     extent_time_format='lst')
-    cp.INS_plot(ins, log_prefix, log=True, xticks=xticks, yticks=yticks,
-                xticklabels=xticklabels, yticklabels=yticklabels, title='Title')
+    with pytest.warns(UserWarning, match="Plotting keyword"):
+        cp.INS_plot(ins, log_prefix, log=True, xticks=xticks, yticks=yticks,
+                    xticklabels=xticklabels, yticklabels=yticklabels,
+                    title='Title')
     cp.INS_plot(ins, symlog_prefix, symlog=True, xticks=xticks, yticks=yticks,
                 xticklabels=xticklabels, yticklabels=yticklabels,
                 use_extent=False)
@@ -86,6 +89,7 @@ def test_sig_plot():
     os.rmdir(outdir)
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")
 def test_VDH_plot():
 
     matplotlib = pytest.importorskip("matplotlib")
@@ -115,6 +119,7 @@ def test_VDH_plot():
     os.rmdir(outdir)
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")
 def test_VDH_no_model():
 
     matplotlib = pytest.importorskip("matplotlib")

--- a/SSINS/tests/test_util.py
+++ b/SSINS/tests/test_util.py
@@ -111,12 +111,13 @@ def test_make_ticks():
     assert np.all(labels == test_labels), "The labels are not equal"
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")
 def test_combine_ins():
     obs = "1061313128_99bl_1pol_half_time"
     testfile = os.path.join(DATA_PATH, f"{obs}.uvfits")
 
     ss = SS()
-    ss.read(testfile)
+    ss.read(testfile, diff=True)
 
     whole_ins = INS(ss)
 
@@ -143,6 +144,7 @@ def test_combine_ins():
         assert np.all(np.isclose(getattr(whole_ins, attr), getattr(ins_first_50, attr))), f"{attr} is not equal between the two INS"
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")
 def test_combine_ins_use_nsample():
     obs = "1061313128_99bl_1pol_half_time"
     testfile = os.path.join(DATA_PATH, f"{obs}.uvfits")
@@ -169,6 +171,7 @@ def test_combine_ins_use_nsample():
         assert np.all(np.isclose(getattr(whole_ins, attr), getattr(test_ins, attr))), f"{attr} is not equal between the two INS"
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering", "ignore:Requested")
 def test_combine_ins_errors():
     obs = "1061313128_99bl_1pol_half_time"
     testfile = os.path.join(DATA_PATH, f"{obs}.uvfits")
@@ -218,6 +221,7 @@ def test_combine_ins_errors():
         new_ins = util.combine_ins(ins_first_50, ins_remaining)
 
 
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")
 def test_write_meta():
     obs = "1061313128_99bl_1pol_half_time"
     testfile = os.path.join(DATA_PATH, f"{obs}.uvfits")


### PR DESCRIPTION
This PR puts some pytest warning filters in the test suite so that the user is not blasted with superfluous warnings while running tests.