### PR TITLE
Change how version information is generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ venv.bak/
 
 # install files
 SSINS/GIT_INFO
+SSINS/version.py

--- a/SSINS/__init__.py
+++ b/SSINS/__init__.py
@@ -12,9 +12,6 @@ from .incoherent_noise_spectrum import *
 from .plot_lib import *
 from .match_filter import *
 from .sky_subtract import *
-from setuptools_scm import get_version
-from pathlib import Path
-from pyuvdata.branch_scheme import branch_scheme
+from . import version as _version
 
-version_str = get_version(Path(__file__).parent.parent, local_scheme=branch_scheme)
-__version__ = version_str
+__version__ = _version.version

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def branch_scheme(version):
     if version.exact or version.node is None:
         return version.format_choice("", "+d{time:{time_format}}", time_format="%Y%m%d")
     else:
-        if version.branch == "main":
+        if version.branch in ["main", "master"]:
             return version.format_choice("+{node}", "+{node}.dirty")
         else:
             return version.format_choice("+{node}.{branch}", "+{node}.{branch}.dirty")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,20 @@ import os
 import sys
 import json
 
-sys.path.append('SSINS')
+
+def branch_scheme(version):
+    """
+    Local version scheme that adds the branch name for absolute reproducibility.
+
+    If and when this is added to setuptools_scm this function and file can be removed.
+    """
+    if version.exact or version.node is None:
+        return version.format_choice("", "+d{time:{time_format}}", time_format="%Y%m%d")
+    else:
+        if version.branch == "main":
+            return version.format_choice("+{node}", "+{node}.dirty")
+        else:
+            return version.format_choice("+{node}.{branch}", "+{node}.{branch}.dirty")
 
 
 def package_files(package_dir, subdirectory):
@@ -36,7 +49,10 @@ setup_args = {
                 'scripts/occ_csv.py'],
     'package_data': {'SSINS': data_files},
     'setup_requires': ['setuptools_scm'],
-    'use_scm_version': True,
+    'use_scm_version': {
+        "write_to": "SSINS/version.py",
+        "local_scheme": branch_scheme,
+    },
     'install_requires': ['pyuvdata', 'h5py', 'pyyaml'],
     'zip_safe': False,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR changes how the version information is generated and saved in SSINS to be more robust and flexible. Previously, it seemed that a local installation with `pip install -e .` was required so that the package could query the git status of the repo on package import, but this change allows for the repo to be installed anywhere. The version information is generated by `setuptools_scm` on package setup and written to `SSINS/version.py`, which is then used to set the package's `__version__` attribute.

The biggest difference is that the `branch_scheme` for `setuptools_scm` from pyuvdata is no longer imported from the package, but has instead been copied to `setup.py`. This was required so that the version information could be generated without adding pyuvdata as a setup dependency, which would be quite a heavy requirement.

I have not added an entry to the CHANGELOG because it seems relatively minor and primarily related to packaging. If an entry is still desired, I can add one quickly.

## Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->

Main Code Body Checklist:
- [ ] Add or update docstring related to code change
- [ ] Add a unit test that verifies the efficacy of the code
- [ ] Write a tutorial if the feature would be useful to others to use
- [ ] Update CHANGELOG.md

Scripts Checklist:
- [ ] Add useful help strings for any arguments that are parsed
- [ ] Manually check that the script runs and gives proper results
- [ ] Update CHANGELOG.md
