### PR TITLE
Optimize differencing in  time

### DIFF
--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -216,7 +216,6 @@ class SS(UVData):
                           'nsample_array', 'integration_time', 'baseline_array',
                           'ant_1_array', 'ant_2_array', 'uvw_array' ]
         if(hasattr(self, 'phase_center_app_dec')):
-            print('yes')
             blt_attr_names.append('phase_center_app_dec')
         if(hasattr(self, 'phase_center_app_ra')):
             blt_attr_names.append('phase_center_app_ra')

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -112,7 +112,7 @@ class SS(UVData):
         The flags are propagated by taking the boolean OR of the entries that correspond
         to the visibilities that are differenced from one another. Other metadata
         attributes are also adjusted so that the resulting SS object passes
-        UVData.check()
+        UVData.check().
         """
         # want to reorder to baseline order
         # baseline order guarantees that the baseline time axis is oriented so that we can safely assume where indices for diffing are
@@ -121,7 +121,7 @@ class SS(UVData):
             warnings.warn("Reordering data array to baseline order to perform differencing.")
             self.reorder_blts(order='baseline')
 
-        # basline index: indicates which bl (in bl order) is being processed
+        # baseline index: indicates which bl (in bl order) is being processed
         bl_num = 0
 
         # Just treat every baseline independently - make no assumptions other than what is guaranteed by baseline ordered objects
@@ -136,7 +136,7 @@ class SS(UVData):
         bltaxisboundaries = bltaxisboundaries + 1                               # offset entries to correct distance between 0th index and 1st
         bltaxisboundaries = np.insert(bltaxisboundaries, 0, 0)                  # add 0 to beginning of array (diff won't be able to catch this)
 
-        #need a second array representing what the output's shape will look like -- it's smaller by Nbls because of diffing
+        # need a second array representing what the output's shape will look like -- it's smaller by Nbls because of diffing
         diffed_baseline_array = self.baseline_array
         for bl in np.unique(self.baseline_array):
             index = (np.argwhere(diffed_baseline_array == bl)[0:1])

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -187,12 +187,16 @@ class SS(UVData):
             diff_uvw = self.uvw_array[where_bl]
             diff_uvw = 0.5 * (diff_uvw[:-1] + diff_uvw[1:])
 
-            diff_pcad = self.phase_center_app_dec[where_bl]
-            diff_pcad = 0.5 * (diff_pcad[:-1] + diff_pcad[1:])
-            diff_pcar = self.phase_center_app_ra[where_bl]
-            diff_pcar = 0.5 * (diff_pcar[:-1] + diff_pcar[1:])
-            diff_pcfp = self.phase_center_frame_pa[where_bl]
-            diff_pcfp = 0.5 * (diff_pcfp[:-1] + diff_pcfp[1:])
+            #pyuvdata 2.2 optional parameters
+            if(hasattr(self, 'phase_center_app_dec')):
+                diff_pcad = self.phase_center_app_dec[where_bl]
+                diff_pcad = 0.5 * (diff_pcad[:-1] + diff_pcad[1:])
+            if(hasattr(self, 'phase_center_app_ra')):
+                diff_pcar = self.phase_center_app_ra[where_bl]
+                diff_pcar = 0.5 * (diff_pcar[:-1] + diff_pcar[1:])
+            if(hasattr(self, 'phase_center_frame_pa')):
+                diff_pcfp = self.phase_center_frame_pa[where_bl]
+                diff_pcfp = 0.5 * (diff_pcfp[:-1] + diff_pcfp[1:])
 
             self.integration_time[blt_slice] = diff_ints
             """Total amount of integration time (sum of the differenced visibilities) at each baseline-time (length Nblts)"""
@@ -208,11 +212,17 @@ class SS(UVData):
         self.Ntimes -= 1                                                        # diffing adjacent times reduces size of time array by one
         """Total number of integration times in the data. Equal to the original Ntimes-1."""
 
-        for blts_attr in ['data_array', 'flag_array', 'time_array',
+        blt_attr_names =  ['data_array', 'flag_array', 'time_array',
                           'nsample_array', 'integration_time', 'baseline_array',
-                          'ant_1_array', 'ant_2_array', 'uvw_array',
-                          'phase_center_app_dec', 'phase_center_app_ra',
-                          'phase_center_frame_pa']:
+                          'ant_1_array', 'ant_2_array', 'uvw_array' ]
+        if(hasattr(self, 'phase_center_app_dec')):
+            print('yes')
+            blt_attr_names.append('phase_center_app_dec')
+        if(hasattr(self, 'phase_center_app_ra')):
+            blt_attr_names.append('phase_center_app_ra')
+        if(hasattr(self, 'phase_center_frame_pa')):
+            blt_attr_names.append('phase_center_frame_pa')
+        for blts_attr in blt_attr_names:
             setattr(self, blts_attr, getattr(self, blts_attr)[:-self.Nbls])
 
         super().set_lsts_from_time_array()

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -150,8 +150,7 @@ class SS(UVData):
 
         # loop through each baseline in the baseline_array, noting that the baseline_array will have each bl repeated for ntimes
         # (so we need unique)
-        for bl in np.unique(self.baseline_array):
-
+        for bl_num, bl in enumerate(np.unique(self.baseline_array)):
             # blstart to blend delineates a series of baseline-time axis entries with the same baseline
             blstart = bltaxisboundaries[bl_num]                                 # index in baseline-time axis to start
             blend = bltaxisboundaries[bl_num+1]                                 # index in baseline-time axis to end
@@ -204,7 +203,6 @@ class SS(UVData):
 
             self.baseline_array[blt_slice] = bl
             self.ant_1_array[blt_slice], self.ant_2_array[blt_slice] = self.baseline_to_antnums(bl)
-            bl_num += 1                                                         #increment the baseline counter, now that we're done
 
         # Adjust the UVData attributes.
         self.Nblts -= self.Nbls                                                 # size of baseline-time axis is Nblts shorter (one time from each bl)

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -187,6 +187,13 @@ class SS(UVData):
             diff_uvw = self.uvw_array[where_bl]
             diff_uvw = 0.5 * (diff_uvw[:-1] + diff_uvw[1:])
 
+            diff_pcad = self.phase_center_app_dec[where_bl]
+            diff_pcad = 0.5 * (diff_pcad[:-1] + diff_pcad[1:])
+            diff_pcar = self.phase_center_app_ra[where_bl]
+            diff_pcar = 0.5 * (diff_pcar[:-1] + diff_pcar[1:])
+            diff_pcfp = self.phase_center_frame_pa[where_bl]
+            diff_pcfp = 0.5 * (diff_pcfp[:-1] + diff_pcfp[1:])
+
             self.integration_time[blt_slice] = diff_ints
             """Total amount of integration time (sum of the differenced visibilities) at each baseline-time (length Nblts)"""
             self.uvw_array[blt_slice] = diff_uvw
@@ -203,7 +210,9 @@ class SS(UVData):
 
         for blts_attr in ['data_array', 'flag_array', 'time_array',
                           'nsample_array', 'integration_time', 'baseline_array',
-                          'ant_1_array', 'ant_2_array', 'uvw_array']:
+                          'ant_1_array', 'ant_2_array', 'uvw_array',
+                          'phase_center_app_dec', 'phase_center_app_ra',
+                          'phase_center_frame_pa']:
             setattr(self, blts_attr, getattr(self, blts_attr)[:-self.Nbls])
 
         super().set_lsts_from_time_array()

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -136,7 +136,7 @@ class SS(UVData):
         bltaxisboundaries = bltaxisboundaries + 1                               # offset entries to correct distance between 0th index and 1st
         bltaxisboundaries = np.insert(bltaxisboundaries, 0, 0)                  # add 0 to beginning of array (diff won't be able to catch this)
 
-        #need a second array representing what the output's shape will look like -- it's smaller by Nblts because of diffing
+        #need a second array representing what the output's shape will look like -- it's smaller by Nbls because of diffing
         diffed_baseline_array = self.baseline_array
         for bl in np.unique(self.baseline_array):
             index = (np.argwhere(diffed_baseline_array == bl)[0:1])

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -115,6 +115,8 @@ class SS(UVData):
         UVData.check()
         """
         # want to reorder to baseline order
+        # baseline order guarantees that the baseline time axis is oriented so that we can safely assume where indices for diffing are
+        # by looking at the blt axis array
         if self.blt_order != 'baseline':
             warnings.warn("Reordering data array to baseline order to perform differencing.")
             self.reorder_blts(order='baseline')
@@ -131,7 +133,7 @@ class SS(UVData):
 
         bltaxisboundaries = np.nonzero(testarray)
         bltaxisboundaries = np.append(bltaxisboundaries, np.size(testarray, 0)) # add last value to end of array (diff won't be able to catch this)
-        bltaxisboundaries = bltaxisboundaries + 1
+        bltaxisboundaries = bltaxisboundaries + 1                               # offset entries to correct distance between 0th index and 1st
         bltaxisboundaries = np.insert(bltaxisboundaries, 0, 0)                  # add 0 to beginning of array (diff won't be able to catch this)
 
         #need a second array representing what the output's shape will look like -- it's smaller by Nblts because of diffing
@@ -164,8 +166,8 @@ class SS(UVData):
             diff_nsamples = 0.5 * (diff_nsamples[:-1] + diff_nsamples[1:])      # average together adjacent nsamples
             len_diff = diff_dat.shape[0]
 
-            blstart = bltaxisboundaries2[bl_num]                                 # index in baseline-time axis to start
-            blend = bltaxisboundaries2[bl_num+1]                                 # index in baseline-time axis to end
+            blstart = bltaxisboundaries2[bl_num]                                # index in baseline-time axis to start
+            blend = bltaxisboundaries2[bl_num+1]                                # index in baseline-time axis to end
 
             blt_slice = slice(blstart, blstart+len_diff)
             self.data_array[blt_slice, :, :, :] = diff_dat


### PR DESCRIPTION
This pull request approximately doubles the speed of the diff() function in sky_subtract.

## Description
The original diff() function calls pyuvdata's safe data grabbing functions to get data to diff. However, the dataset is already put in baseline form, which ensures that the data's ordering is known, and therefore the overhead of these functions is not necessary. As a result, the new diff() is somewhat more than twice as fast as the old one (according to my machine [E5 2440 v2 @1.9 Ghz] and cProfile).

The new implementation of diff starts by allocating two indexing arrays which copy the baseline array. By differencing the baseline array between adjacent members, and knowing that the array is in baseline form, it can be seen that the only nonzero members of the array are at boundaries between different baselines. By doing this for two arrays, representing the original dataset (before removing baselines for differencing) and afterwards (with one baseline entry removed per baseline) we get a map of the dataset's structure before and after the differencing has happened. Using these two arrays, then, we can traverse the indices needed to select data to difference much faster than manually querying using pyuvdata's builtin functions.  

### pyuvdata 2.2 patch

Additionally, to accomodate the new pyuvdata 2.2 release, which has new data parameters, this PR includes the code required to diff them properly (by averaging). Since the parameters are optional, however, this PR does not break compatibility with previously supported versions of the library.

### Main Code Body Checklist:

I do not believe most of these requirements are applicable, this is a drop in change (no functionality changes, besides compatibility)
- [ ] ~~Add or update docstring related to code change~~
- [ ] ~~Add a unit test that verifies the efficacy of the code~~
- [ ] ~~Write a tutorial if the feature would be useful to others to use~~
- [ ] Update CHANGELOG.md

If the pull request is in a mergeable state, I can update the CHANGELOG and the library requirements to suit at that time, to avoid dealing with a potential merge issue.