### PR TITLE
pipe xscale kwarg to hist_plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # SSINS Change Log
 
 ## Unreleased
+- Fixed xscale kwarg passing bug in plotting code
 - Updated MWA_EoR_High_uvfits_write and then moved it to the EoRImaging/pipeline_scripts repo
 - Change version handling to use setuptools_scm.
 - Update Run_HERA_SSINS.py to take auto_metrics and ant_metrics files to calculate

--- a/SSINS/Catalog_Plot.py
+++ b/SSINS/Catalog_Plot.py
@@ -225,7 +225,7 @@ def VDH_plot(SS, prefix, file_ext='pdf', xlabel='', xscale='linear', yscale='log
         else:
             model_func = None
         hist_plot(fig, ax, np.abs(SS.data_array[np.logical_not(SS.data_array.mask)]),
-                  bins=bins, legend=legend, model_func=model_func,
+                  bins=bins, legend=legend, model_func=model_func, xscale=xscale,
                   yscale=yscale, ylim=ylim, density=density, label=post_label,
                   xlabel=xlabel, error_sig=error_sig, alpha=alpha,
                   model_label=post_model_label, color=post_color,
@@ -242,7 +242,7 @@ def VDH_plot(SS, prefix, file_ext='pdf', xlabel='', xscale='linear', yscale='log
             temp_choice = 'original'
         SS.apply_flags(flag_choice=None)
         hist_plot(fig, ax, np.abs(SS.data_array).flatten(), bins=bins,
-                  legend=legend, model_func=model_func, yscale=yscale,
+                  legend=legend, model_func=model_func, xscale=xscale, yscale=yscale,
                   ylim=ylim, density=density, label=pre_label, alpha=alpha,
                   xlabel=xlabel, error_sig=error_sig, model_label=pre_model_label,
                   color=pre_color, model_color=pre_model_color, font_size=font_size)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a simple fix where I just ensured that the `xscale` kwarg was being passed into `hist_plot` from `VDH_plot`. Closes #108 

## Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->

Main Code Body Checklist:
- [ ] Add or update docstring related to code change
- [ ] Add a unit test that verifies the efficacy of the code
- [ ] Write a tutorial if the feature would be useful to others to use
- [x] Update CHANGELOG.md

Scripts Checklist:
- [ ] Add useful help strings for any arguments that are parsed
- [ ] Manually check that the script runs and gives proper results
- [ ] Update CHANGELOG.md
