### PR TITLE
Call apply flags after diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # SSINS Change Log
 
 ## Unreleased
+- Call SS.apply_flags at end of SS.diff so that object is always ready to pass
+to INS after diff
 - Fixed xscale kwarg passing bug in plotting code
 - Updated MWA_EoR_High_uvfits_write and then moved it to the EoRImaging/pipeline_scripts repo
 - Change version handling to use setuptools_scm.

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -49,8 +49,7 @@ class SS(UVData):
 
         if (self.data_array is not None):
             if diff:
-                self.diff()
-                self.apply_flags(flag_choice=flag_choice, INS=INS, custom=custom)
+                self.diff(flag_choice=flag_choice, INS=INS, custom=custom)
             else:
                 # This warning will be issued when diff is False and there is some data read in
                 # If filename is a list of files, then this warning will get issued in the recursive call in UVData.read
@@ -104,7 +103,7 @@ class SS(UVData):
         else:
             raise ValueError('flag_choice of %s is unacceptable, aborting.' % flag_choice)
 
-    def diff(self):
+    def diff(self, flag_choice=None, INS=None, custom=None):
 
         """
         Differences the visibilities in time. Does so independently for each baseline,
@@ -112,7 +111,18 @@ class SS(UVData):
         The flags are propagated by taking the boolean OR of the entries that correspond
         to the visibilities that are differenced from one another. Other metadata
         attributes are also adjusted so that the resulting SS object passes
-        UVData.check().
+        UVData.check(). Will then call self.apply_flags using the keyword
+        arguments.
+
+        Args:
+            flag_choice (None, 'original', 'INS', 'custom'):
+                Applies flags according to the choice. None unflags the data.
+                'original' applies flags based on the flag_array attribute.
+                'INS' applies flags from an INS object specified by the INS keyword.
+                'custom' applies a custom flag array specified by the custom keyword
+                - it must be the same shape as the data.
+            INS: An INS from which to apply flags - only used if flag_choice='INS'
+            custom: A custom flag array from which to apply flags - only used if flag_choice='custom'
         """
         # want to reorder to baseline order
         # baseline order guarantees that the baseline time axis is oriented so that we can safely assume where indices for diffing are
@@ -224,6 +234,7 @@ class SS(UVData):
 
         super().set_lsts_from_time_array()
         self.data_array = np.ma.masked_array(self.data_array)
+        self.apply_flags(flag_choice=None, INS=None, custom=None)
 
     def MLE_calc(self):
 

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -234,7 +234,7 @@ class SS(UVData):
 
         super().set_lsts_from_time_array()
         self.data_array = np.ma.masked_array(self.data_array)
-        self.apply_flags(flag_choice=None, INS=None, custom=None)
+        self.apply_flags(flag_choice=flag_choice, INS=INS, custom=custom)
 
     def MLE_calc(self):
 

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -120,6 +120,19 @@ def test_apply_flags():
         ss.apply_flags(flag_choice='bad_choice')
 
 
+def test_apply_flags_on_diff():
+    obs = '1061313128_99bl_1pol_half_time'
+    testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)
+    file_type = 'uvfits'
+    insfile = os.path.join(DATA_PATH, '%s_SSINS.h5' % obs)
+    ss = SS()
+
+    ss.read(testfile, diff=True, flag_choice='original')
+
+    assert np.all(ss.flag_array == ss.data_array.mask), "Flag arrays are not equal"
+    assert ss.flag_choice == 'original', "Flag choice attribute was not changed"
+
+
 @pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering",
                             "ignore:diff on read")
 def test_mixture_prob():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a quick PR to always call SS.apply_flags after SS.diff, since they are basically never executed without one another, and in fact SS.apply_flags is required in order for a diff'd object to be passed to INS.

## Description
<!--- Describe your changes in detail -->
See general summary

## Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->

Main Code Body Checklist:
- [x] Add or update docstring related to code change
- [ ] Add a unit test that verifies the efficacy of the code
- [ ] Write a tutorial if the feature would be useful to others to use
- [x] Update CHANGELOG.md

Scripts Checklist:
- [ ] Add useful help strings for any arguments that are parsed
- [ ] Manually check that the script runs and gives proper results
- [ ] Update CHANGELOG.md
