### PR TITLE
Change antpair request in unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # SSINS Change Log
 
 ## Unreleased
+- Update diff unit test to be more flexible with pyuvdata antenna_number conventions
 - Call SS.apply_flags at end of SS.diff so that object is always ready to pass
 to INS after diff
 - Fixed xscale kwarg passing bug in plotting code

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -41,7 +41,8 @@ def test_diff():
     # Read in two times and two baselines of data, so that the diff is obvious.
     uv.read(testfile, read_data=False)
     times = np.unique(uv.time_array)[:2]
-    bls = [(0, 1), (0, 2)]
+    bls = [(uv.antenna_numbers[0], uv.antenna_numbers[1]),
+           (uv.antenna_numbers[0], uv.antenna_numbers[2])]
     uv.read(testfile, times=times, bls=bls)
     uv.reorder_blts(order='baseline')
 
@@ -62,8 +63,8 @@ def test_diff():
     assert np.all(ss.nsample_array == diff_nsamples), "nsample_array is different!"
     assert np.all(ss.integration_time == diff_ints), "Integration times are different"
     assert np.all(ss.uvw_array == diff_uvw), "uvw_arrays disagree!"
-    assert np.all(ss.ant_1_array == np.array([0, 0])), "ant_1_array disagrees!"
-    assert np.all(ss.ant_2_array == np.array([1, 2])), "ant_2_array disagrees!"
+    assert np.all(ss.ant_1_array == np.array([uv.antenna_numbers[0], uv.antenna_numbers[0]])), f"ant_1_array disagrees!"
+    assert np.all(ss.ant_2_array == np.array([uv.antenna_numbers[1], uv.antenna_numbers[2]])), "ant_2_array disagrees!"
 
 
 @pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change a unit test so that it is more flexible with pyuvdata version

## Description
<!--- Describe your changes in detail -->
For some currently unknown reason, pyuvdata 2.2.8 reads one of the test files in with its first antenna number being 0, while pyuvdata 2.2.9 reads it in with it being equal to 1. This was causing a unit test to fail since the requested antpairs in a downselect were hard coded. The hard code was able to be removed while preserving the spirit of the test.

## Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->

Main Code Body Checklist:
- [ ] Add or update docstring related to code change
- [x] Add a unit test that verifies the efficacy of the code
- [ ] Write a tutorial if the feature would be useful to others to use
- [x] Update CHANGELOG.md

Scripts Checklist:
- [ ] Add useful help strings for any arguments that are parsed
- [ ] Manually check that the script runs and gives proper results
- [ ] Update CHANGELOG.md
