### PR TITLE
Plot revamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # SSINS Change Log
 
 ## Unreleased
-- Got rid of old matplotlib functionality that was deprecated
+- **notable api change** Got rid of old matplotlib functionality that was deprecated. Must now supply a _string_ for the cmap argument in all the plotting code, which is the name of the colormap you would like to use, rather than the actual colormap object.
 - Update diff unit test to be more flexible with pyuvdata antenna_number conventions
 - Call SS.apply_flags at end of SS.diff so that object is always ready to pass
 to INS after diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # SSINS Change Log
 
 ## Unreleased
+- Got rid of old matplotlib functionality that was deprecated
 - Update diff unit test to be more flexible with pyuvdata antenna_number conventions
 - Call SS.apply_flags at end of SS.diff so that object is always ready to pass
 to INS after diff

--- a/SSINS/Catalog_Plot.py
+++ b/SSINS/Catalog_Plot.py
@@ -37,7 +37,7 @@ def INS_plot(INS, prefix, file_ext='pdf', xticks=None, yticks=None, vmin=None,
         vmax (float): The maximum of the colormap for the INS (non-mean-subtracted)
         ms_vmin (float): The minimum of the colormap for the mean-subtracted INS
         ms_vmax (float): The maximum of the colormap for the mean-subtracted INS
-        data_cmap (colormap): The colormap for the non-mean-subtracted data
+        data_cmap (str): The colormap for the non-mean-subtracted data
         xticklabels (sequence of str): The labels for the frequency ticks
         yticklabels (sequence of str): The labels for the time ticks
         aspect (float or 'auto' or 'equal'): Set the aspect ratio of the waterfall plots.
@@ -99,7 +99,7 @@ def INS_plot(INS, prefix, file_ext='pdf', xticks=None, yticks=None, vmin=None,
                     'linthresh': linthresh},
                    {'cbar_label': 'Deviation ($\hat{\sigma})$',
                     'mask_color': 'black',
-                    'cmap': cm.coolwarm,
+                    'cmap': 'coolwarm',
                     'vmin': ms_vmin,
                     'vmax': ms_vmax,
                     'cbar_ticks': ms_cbar_ticks,
@@ -112,7 +112,7 @@ def INS_plot(INS, prefix, file_ext='pdf', xticks=None, yticks=None, vmin=None,
                          'cmap': sig_cmap,
                          'midpoint': False},
                         {'cbar_label': 'Event Index',
-                         'cmap': cm.viridis_r,
+                         'cmap': 'viridis_r',
                          'mask_color': 'white',
                          'midpoint': False,
                          'log': False,
@@ -121,7 +121,7 @@ def INS_plot(INS, prefix, file_ext='pdf', xticks=None, yticks=None, vmin=None,
                          'vmin': sample_sig_vmin,
                          'vmax': sample_sig_vmax,
                          'midpoint': True,
-                         'cmap': cm.coolwarm,
+                         'cmap': 'coolwarm',
                          'mask_color': 'black'}]
 
     fig, ax = plt.subplots(nrows=INS.metric_array.shape[2],

--- a/SSINS/plot_lib.py
+++ b/SSINS/plot_lib.py
@@ -205,7 +205,7 @@ def hist_plot(fig, ax, data, bins='auto', yscale='log', xscale='linear',
             yerr = error_sig * np.append(yerr, 0)
             ax.fill_between(bins, model_y - yerr, model_y + yerr, alpha=alpha,
                             step='post', color=model_color)
-            model_label += ' and %s$\sigma$ Uncertainty' % error_sig
+            model_label += ' and %s' % (error_sig) + r'$\sigma$ Uncertainty'
         ax.plot(bins, model_y, label=model_label, drawstyle='steps-post', color=model_color)
 
     if legend:

--- a/SSINS/plot_lib.py
+++ b/SSINS/plot_lib.py
@@ -124,20 +124,24 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
     elif convert_times:
         # This case is for when extent is set, manual settings have not been made, and conversion is desired.
         # Otherwise just use what came from extent
+        yticks = ax.get_yticks()
         if extent_time_format.lower() == 'jd':
-            ax.set_yticklabels([Time(ytick, format='jd').iso[:-4] for ytick in ax.get_yticks()])
+            yticklabels = [Time(ytick, format='jd').iso[:-4] for ytick in yticks]
         elif extent_time_format.lower() == 'lst':
-            ax.set_yticklabels([Longitude(ytick * units.radian).hourangle for ytick in ax.get_yticks()])
+            set_yticklabels = [Longitude(ytick * units.radian).hourangle for ytick in yticks]
+        set_ticks_labels(ax, xticks, yticks, xticklabels, yticklabels)
 
     cbar.ax.tick_params(labelsize=font_size)
     ax.tick_params(labelsize=font_size)
 
 
 def set_ticks_labels(ax, xticks, yticks, xticklabels, yticklabels):
+    from matplotlib import ticker
+
     if xticks is not None:
-        ax.set_xticks(xticks)
+        ax.xaxis.set_major_locator(ticker.FixedLocator(xticks))
     if yticks is not None:
-        ax.set_yticks(yticks)
+        ax.yaxis.set_major_locator(ticker.FixedLocator(yticks))
     if xticklabels is not None:
         ax.set_xticklabels(xticklabels)
     if yticklabels is not None:

--- a/SSINS/plot_lib.py
+++ b/SSINS/plot_lib.py
@@ -67,12 +67,12 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
             super().__init__(vmin, vmax, clip)
 
         def __call__(self, value, clip=None):
-            # I'm ignoring masked values and all kinds of edge cases to make a
-            # simple example...
             # Note also that we must extrapolate beyond vmin/vmax
+            result, is_scalar = self.process_value(value)
             x, y = [self.vmin, self.vcenter, self.vmax], [0, 0.5, 1.]
             return np.ma.masked_array(np.interp(value, x, y,
-                                                left=-np.inf, right=np.inf))
+                                                left=-np.inf, right=np.inf),
+                                                mask=result.mask)
 
         def inverse(self, value):
             y, x = [self.vmin, self.vcenter, self.vmax], [0, 0.5, 1]

--- a/SSINS/plot_lib.py
+++ b/SSINS/plot_lib.py
@@ -7,6 +7,7 @@ from astropy.time import Time
 from astropy import units
 from astropy.coordinates import Longitude
 import warnings
+import copy
 
 
 def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
@@ -62,6 +63,8 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
 
     if cmap is None:
         cmap = 'plasma'
+    colormap = copy(getattr(cm, cmap)) # Copy so as not to mutate the global cmap instance
+    colormap.set_bad(color=mask_color)
 
     # Make sure it does the yticks correctly
     if extent is not None:
@@ -71,22 +74,23 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
 
     # colorization methods: linear, normalized log, symmetrical log
     if midpoint:
-        cax = ax.imshow(data, cmap=cmap, aspect=aspect, interpolation='none',
+        cax = ax.imshow(data, cmap=colormap, aspect=aspect, interpolation='none',
                         norm=colors.CenteredNorm(vmin=vmin, vmax=vmax),
                         extent=extent, alpha=alpha)
     elif log:
-        cax = ax.imshow(data, cmap=cmap, norm=colors.LogNorm(), aspect=aspect,
+        cax = ax.imshow(data, cmap=colormap, norm=colors.LogNorm(), aspect=aspect,
                         vmin=vmin, vmax=vmax, interpolation='none',
                         extent=extent, alpha=alpha)
     elif symlog:
-        cax = ax.imshow(data, cmap=cmap, norm=colors.SymLogNorm(linthresh), aspect=aspect,
+        cax = ax.imshow(data, cmap=colormap, norm=colors.SymLogNorm(linthresh), aspect=aspect,
                         vmin=vmin, vmax=vmax, interpolation='none',
                         extent=extent, alpha=alpha)
     else:
-        cax = ax.imshow(data, cmap=cmap, vmin=vmin, vmax=vmax, aspect=aspect,
+        cax = ax.imshow(data, cmap=colormap, vmin=vmin, vmax=vmax, aspect=aspect,
                         interpolation='none', extent=extent, alpha=alpha)
 
-    cmap.set_bad(color=mask_color)
+
+
     cbar = fig.colorbar(cax, ax=ax, ticks=cbar_ticks, extend=extend)
     cbar.set_label(cbar_label, fontsize=font_size)
 

--- a/SSINS/plot_lib.py
+++ b/SSINS/plot_lib.py
@@ -54,7 +54,7 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
 
     Note for arguments midpoint, log, symlog, linthresh:
         * Only one of these arguments can be expressed in the plot (can't have a plot with multiple different colorbar metrics).
-        * If multiple of these arguments are passed, default is linear (midpoint) followed by log, symlog.
+        * If multiple of these arguments are passed, default is linear (centered) followed by log, symlog.
         * Linthresh only applies when using symmetrical log (symlog) and will be ignored otherwise.
     """
 
@@ -62,29 +62,6 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
 
     if cmap is None:
         cmap = 'plasma'
-
-    class MidpointNormalize(colors.Normalize):
-
-        """
-        A short class which is used by image_plot to keep zero at the color-center
-        of diverging colormaps.
-        """
-
-        def __init__(self, vmin=None, vmax=None, midpoint=None, clip=False):
-            """
-            A short init line using inheritance
-            """
-            self.midpoint = midpoint
-            colors.Normalize.__init__(self, vmin, vmax, clip)
-
-        def __call__(self, value, clip=None):
-            """
-            Colormapping function
-            """
-            # ignoring masked values and all kinds of edge cases
-            result, is_scalar = self.process_value(value)
-            x, y = [self.vmin, self.midpoint, self.vmax], [0, 0.5, 1]
-            return np.ma.array(np.interp(value, x, y), mask=result.mask, copy=False)
 
     # Make sure it does the yticks correctly
     if extent is not None:
@@ -95,7 +72,7 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
     # colorization methods: linear, normalized log, symmetrical log
     if midpoint:
         cax = ax.imshow(data, cmap=cmap, aspect=aspect, interpolation='none',
-                        norm=MidpointNormalize(midpoint=0, vmin=vmin, vmax=vmax),
+                        norm=colors.CenteredNorm(vmin=vmin, vmax=vmax),
                         extent=extent, alpha=alpha)
     elif log:
         cax = ax.imshow(data, cmap=cmap, norm=colors.LogNorm(), aspect=aspect,

--- a/SSINS/plot_lib.py
+++ b/SSINS/plot_lib.py
@@ -24,7 +24,7 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
         fig: The fig object to modify
         ax: The axis object to modify
         data: The data to plot
-        cmap: A colormap from matplotlib.cm e.g. cm.coolwarm
+        cmap: Name of a colormap from matplotlib
         vmin: The minimum value for the colormap
         vmax: The maximum value for the colormap
         title: The title for ax
@@ -61,7 +61,7 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
     from matplotlib import colors, cm
 
     if cmap is None:
-        cmap = cm.plasma
+        cmap = 'plasma'
 
     class MidpointNormalize(colors.Normalize):
 

--- a/SSINS/plot_lib.py
+++ b/SSINS/plot_lib.py
@@ -92,7 +92,7 @@ def image_plot(fig, ax, data, cmap=None, vmin=None, vmax=None, title='',
     # colorization methods: linear, normalized log, symmetrical log
     if midpoint:
         cax = ax.imshow(data, cmap=colormap, aspect=aspect, interpolation='none',
-                        norm=colors.MidpointNormalize(vcenter=0, vmin=vmin, vmax=vmax),
+                        norm=MidpointNormalize(vcenter=0, vmin=vmin, vmax=vmax),
                         extent=extent, alpha=alpha)
     elif log:
         cax = ax.imshow(data, cmap=colormap, norm=colors.LogNorm(), aspect=aspect,

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -120,7 +120,7 @@ def test_apply_flags():
     with pytest.raises(ValueError):
         ss.apply_flags(flag_choice='bad_choice')
 
-
+@pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")
 def test_apply_flags_on_diff():
     obs = '1061313128_99bl_1pol_half_time'
     testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)

--- a/SSINS/tests/test_plot.py
+++ b/SSINS/tests/test_plot.py
@@ -74,11 +74,6 @@ def test_sig_plot():
     mf = MF(ins.freq_array, sig_thresh, shape_dict=shape_dict)
     mf.apply_match_test(ins)
 
-    xticks = np.arange(0, 384, 96)
-    xticklabels = ['%.1f' % (10**-6 * ins.freq_array[tick]) for tick in xticks]
-    yticks = np.arange(0, 50, 10)
-    yticklabels = ['%i' % (2 * tick) for tick in yticks]
-
     cp.INS_plot(ins, prefix)
 
     assert os.path.exists(outfile), "The first plot was not made"

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -159,7 +159,7 @@ Making and writing an incoherent noise spectrum
   >>> # Let's choose a diverging colorbar and center it on zero using the cmap and midpoint keywords.
   >>> plot_lib.image_plot(fig, ax[1], ins.metric_ms[:, :, 0],
   ...                     title='XX z-scores', xticks=xticks,
-  ...                     xticklabels=xticklabels, cmap=cm.coolwarm,
+  ...                     xticklabels=xticklabels, cmap='coolwarm',
   ...                     midpoint=True)
   >>> fig.savefig('%s_plot_lib_SSINS.pdf' % prefix)
   >>> print(os.path.exists('%s_plot_lib_SSINS.pdf' % prefix))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Redo a few things in the plotting code to avoid using deprecated matplotlib functionality. Would close #105 

## Description
<!--- Describe your changes in detail -->
matplotlib warns against using FixedFormatter for ticks without using FixedLocator. Even though it's never been a problem so far, I've made the plotting code explicitly use FixedLocator when using FixedFormatter (which is implicitly called when handing e.g. set_xticklabels a list or other sequence). It also warns against modifying the globally registered colormap. I've thus made all colormap alternations operate on a copy of the global cmap object. 

## Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->

Main Code Body Checklist:
- [x] Add or update docstring related to code change
- [ ] Add a unit test that verifies the efficacy of the code
- [x] Write a tutorial if the feature would be useful to others to use
- [x] Update CHANGELOG.md

Scripts Checklist:
- [ ] Add useful help strings for any arguments that are parsed
- [ ] Manually check that the script runs and gives proper results
- [ ] Update CHANGELOG.md
