### PR TITLE
Fix windows failing builds by making better unit test architecture

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@master
         with:

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@master
         with:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,6 @@ conda:
 build:
     image: latest
 python:
-   version: 3.6
+   version: 3.10
 python:
    setup_py_install: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SSINS Change Log
 
-## Unreleased
+## 1.4.6
+- Requires pyuvdata 2.2.8 or greater, which changes the astropy dependency. Since
+this version of pyuvdata uses a version of astropy that no longer supports python 3.7,
+we have also dropped that from our CI. However, python 3.10 has been added to the CI.
+- Make unit tests use tmp_path pytest fixtures, which makes running them much cleaner
 - Update diff unit test to be more flexible with pyuvdata antenna_number conventions
 - Call SS.apply_flags at end of SS.diff so that object is always ready to pass
 to INS after diff

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SSINS is a python package intended for radio frequency interference flagging in 
 ## Dependencies
 
 **python3** is now required. Support for python2 has been dropped.<br/>
-**pyuvdata 2.1.2 or newer**.<br/>
+**pyuvdata 2.2.8 or newer**.<br/>
 **pyuvdata has its own dependencies!**<br/>
 See https://github.com/RadioAstronomySoftwareGroup/pyuvdata.  
 **pyyaml 5.3.1 or newer** also for reading and writing SSINS outputs.  

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -112,7 +112,7 @@ class INS(UVFlag):
             if "Initialized spectrum_type:" in self.history:
                 raise ValueError("Requested spectrum type disagrees with saved spectrum. "
                                  "Make opposite choice on initialization.")
-            elif self.spectrum_type == "auto":
+            elif self.spectrum_type == "auto": # Reading in an old file
                 raise ValueError("Reading in a 'cross' spectrum as 'auto'. Check"
                                  " spectrum_type for INS initialization.")
         if not hasattr(self.metric_array, 'mask'):

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -111,12 +111,12 @@ def test_polyfit():
 
 
 @pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read")
-def test_mask_to_flags():
+def test_mask_to_flags(tmp_path):
     obs = '1061313128_99bl_1pol_half_time'
-    testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)
+    testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
     file_type = 'uvfits'
-    prefix = os.path.join(DATA_PATH, '%s_test' % obs)
-    flags_outfile = '%s_SSINS_flags.h5' % prefix
+    prefix = os.path.join(tmp_path, f'{obs}_test')
+    flags_outfile = f'{prefix}_SSINS_flags.h5'
 
     ss = SS()
     ss.read(testfile, diff=True)
@@ -178,23 +178,21 @@ def test_mask_to_flags():
     ins.write(prefix, output_type='flags', uvf=uvf)
     read_uvf = UVFlag(flags_outfile, mode='flag', waterfall=True)
     # Check equality
-    assert read_uvf == uvf, "UVFlag objsect differs after read"
-
-    os.remove(flags_outfile)
+    assert read_uvf == uvf, "UVFlag object differs after read"
 
 
 @pytest.mark.filterwarnings("ignore:Reordering", "ignore:SS.read", "ignore:invalid value")
-def test_write():
+def test_write(tmp_path):
 
     obs = '1061313128_99bl_1pol_half_time'
-    testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)
+    testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
     file_type = 'uvfits'
-    prefix = os.path.join(DATA_PATH, '%s_test' % obs)
-    data_outfile = '%s_SSINS_data.h5' % prefix
-    z_score_outfile = '%s_SSINS_z_score.h5' % prefix
-    mask_outfile = '%s_SSINS_mask.h5' % prefix
-    match_outfile = '%s_SSINS_match_events.yml' % prefix
-    sep_data_outfile = '%s.SSINS.data.h5' % prefix
+    prefix = os.path.join(tmp_path, f'{obs}_test')
+    data_outfile = f'{prefix}_SSINS_data.h5'
+    z_score_outfile = f'{prefix}_SSINS_z_score.h5'
+    mask_outfile = f'{prefix}_SSINS_mask.h5'
+    match_outfile = f'{prefix}_SSINS_match_events.yml'
+    sep_data_outfile = f'{prefix}.SSINS.data.h5'
 
     ss = SS()
     ss.read(testfile, flag_choice='original', diff=True)
@@ -222,19 +220,15 @@ def test_write():
     assert np.all(ins.metric_array.mask == new_ins.metric_array.mask), "Elements of the mask were not equal"
     assert np.all(ins.metric_ms == new_ins.metric_ms), "Elements of the metric_ms were not equal"
     assert np.all(ins.match_events == new_ins.match_events), "Elements of the match_events were not equal"
-    assert os.path.exists(sep_data_outfile), "sep_data_outfile was note written"
-
-    for path in [data_outfile, z_score_outfile, mask_outfile, match_outfile,
-                 sep_data_outfile]:
-        os.remove(path)
+    assert os.path.exists(sep_data_outfile), "sep_data_outfile was not written"
 
 
-def test_write_mwaf():
+def test_write_mwaf(tmp_path):
     from astropy.io import fits
 
     obs = '1061313128_99bl_1pol_half_time_SSINS'
-    testfile = os.path.join(DATA_PATH, '%s.h5' % obs)
-    prefix = os.path.join(DATA_PATH, '%s_test' % obs)
+    testfile = os.path.join(DATA_PATH, f'{obs}.h5')
+    prefix = os.path.join(tmp_path, f'{obs}_test')
     ins = INS(testfile)
     mwaf_files = [os.path.join(DATA_PATH, '1061313128_12.mwaf')]
     bad_mwaf_files = [os.path.join(DATA_PATH, 'bad_file_path')]
@@ -266,19 +260,16 @@ def test_write_mwaf():
     with pytest.raises(ValueError):
         ins.write(prefix, output_type='mwaf', mwaf_files=mwaf_files)
 
-    ins.write('%s_add' % prefix, output_type='mwaf', mwaf_files=mwaf_files,
+    ins.write(f'{prefix}_add', output_type='mwaf', mwaf_files=mwaf_files,
               metafits_file=metafits_file)
-    ins.write('%s_replace' % prefix, output_type='mwaf', mwaf_files=mwaf_files,
+    ins.write(f'{prefix}_replace', output_type='mwaf', mwaf_files=mwaf_files,
               mwaf_method='replace', metafits_file=metafits_file)
 
     with fits.open(mwaf_files[0]) as old_mwaf_hdu:
-        with fits.open('%s_add_12.mwaf' % prefix) as add_mwaf_hdu:
+        with fits.open(f'{prefix}_add_12.mwaf') as add_mwaf_hdu:
             assert np.all(add_mwaf_hdu[1].data['FLAGS'] == old_mwaf_hdu[1].data['FLAGS'] + new_flags)
-    with fits.open('%s_replace_12.mwaf' % prefix) as replace_mwaf_hdu:
+    with fits.open(f'{prefix}_replace_12.mwaf') as replace_mwaf_hdu:
         assert np.all(replace_mwaf_hdu[1].data['FLAGS'] == new_flags)
-
-    for path in ['%s_add_12.mwaf' % prefix, '%s_replace_12.mwaf' % prefix]:
-        os.remove(path)
 
 
 def test_select():
@@ -335,7 +326,7 @@ def test_spectrum_type_file_init():
         ins = INS(cross_testfile, spectrum_type="auto")
 
     del ins
-    ins = INS(cross_testfile)
+    ins = INS(cross_testfile) # I think this line just gets coverage?
     del ins
     ins = INS(auto_testfile, spectrum_type="auto")
 
@@ -398,7 +389,7 @@ def test_mix_spectrum():
 def test_use_integration_weights():
 
     obs = '1061313128_99bl_1pol_half_time'
-    testfile = os.path.join(DATA_PATH, '%s.uvfits' % obs)
+    testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
     file_type = 'uvfits'
 
     ss = SS()

--- a/SSINS/tests/test_MF.py
+++ b/SSINS/tests/test_MF.py
@@ -134,11 +134,11 @@ def test_apply_match_test():
     assert np.all(ins.metric_ms.mask[:, 7:13]), "All the times were not flagged for the shape"
 
 
-def test_time_broadcast():
+def test_time_broadcast(tmp_path):
 
     obs = '1061313128_99bl_1pol_half_time'
     insfile = os.path.join(DATA_PATH, f'{obs}_SSINS.h5')
-    out_prefix = os.path.join(DATA_PATH, f'{obs}_test')
+    out_prefix = os.path.join(tmp_path, f'{obs}_test')
     match_outfile = f'{out_prefix}_SSINS_match_events.yml'
 
     ins = INS(insfile)
@@ -177,7 +177,6 @@ def test_time_broadcast():
     # Test that writing with samp_thresh flags is OK
     ins.write(out_prefix, output_type='match_events')
     test_match_events_read = ins.match_events_read(match_outfile)
-    os.remove(match_outfile)
     assert ins.match_events == test_match_events_read
 
     # Test that exception is raised when tb_aggro is too high
@@ -351,10 +350,10 @@ def test_apply_samp_thresh_dep_error_match_test():
         mf.apply_match_test(ins, apply_samp_thresh=True)
 
 
-def test_MF_write():
+def test_MF_write(tmp_path):
     obs = '1061313128_99bl_1pol_half_time'
     insfile = os.path.join(DATA_PATH, f'{obs}_SSINS.h5')
-    prefix = os.path.join(DATA_PATH, f'{obs}')
+    prefix = os.path.join(tmp_path, f'{obs}')
     outfile = f"{prefix}_test_SSINS_matchfilter.yml"
 
     ins = INS(insfile)
@@ -378,5 +377,3 @@ def test_MF_write():
 
     with pytest.raises(ValueError, match="matchfilter file with prefix"):
         mf.write(f"{prefix}_test", clobber=False)
-
-    os.remove(outfile)

--- a/SSINS/tests/test_MF.py
+++ b/SSINS/tests/test_MF.py
@@ -353,7 +353,8 @@ def test_apply_samp_thresh_dep_error_match_test():
 def test_MF_write(tmp_path):
     obs = '1061313128_99bl_1pol_half_time'
     insfile = os.path.join(DATA_PATH, f'{obs}_SSINS.h5')
-    prefix = os.path.join(tmp_path, f'{obs}')
+    prefix = os.path.join(tmp_path, obs)
+    control_prefix = os.path.join(DATA_PATH, obs)
     outfile = f"{prefix}_test_SSINS_matchfilter.yml"
 
     ins = INS(insfile)
@@ -368,7 +369,7 @@ def test_MF_write(tmp_path):
 
     assert os.path.exists(outfile), "Outfile was not written or has the wrong name."
 
-    with open(f"{prefix}_control_SSINS_matchfilter.yml", 'r') as control_file:
+    with open(f"{control_prefix}_control_SSINS_matchfilter.yml", 'r') as control_file:
         control_dict = yaml.safe_load(control_file)
     control_dict.pop("version")
     test_dict = mf._make_yaml_dict()

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -203,12 +203,12 @@ def test_rev_ind():
 
 @pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering",
                             "ignore:some nsamples", "ignore:elementwise")
-def test_write():
+def test_write(tmp_path):
 
     obs = '1061313128_99bl_1pol_half_time'
     testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
     file_type = 'uvfits'
-    outfile = os.path.join(DATA_PATH, 'test_write.uvfits')
+    outfile = os.path.join(tmp_path, 'test_write.uvfits')
 
     ss = SS()
     ss.read(testfile, diff=True)
@@ -232,7 +232,6 @@ def test_write():
 
     new_blt_inds = np.logical_not(np.isin(UV.time_array, np.unique(UV.time_array)[10:12]))
     assert not np.any(UV.flag_array[new_blt_inds, :, 64:128, :]), "More flags were made than expected"
-    os.remove(outfile)
 
     # Test bad read.
     bad_uv_filepath = os.path.join(DATA_PATH, '1061312640_mix.uvfits')
@@ -242,11 +241,11 @@ def test_write():
         ss.write(outfile, 'uvfits', bad_uv)
 
 
-def test_read_multifiles():
+def test_read_multifiles(tmp_path):
     obs = '1061313128_99bl_1pol_half_time'
     testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
-    new_fp1 = os.path.join(DATA_PATH, f'{obs}_new1.uvfits')
-    new_fp2 = os.path.join(DATA_PATH, f'{obs}_new2.uvfits')
+    new_fp1 = os.path.join(tmp_path, f'{obs}_new1.uvfits')
+    new_fp2 = os.path.join(tmp_path, f'{obs}_new2.uvfits')
     flist = [new_fp1, new_fp2]
 
     file_type = 'uvfits'
@@ -278,9 +277,6 @@ def test_read_multifiles():
 
     assert np.all(np.isclose(ss_orig.data_array, ss_multi.data_array)), "Diffs were different!"
     assert ss_multi.Ntimes == (uvd_full.Ntimes - 1), "Too many diffs were done"
-
-    for path in flist:
-        os.remove(path)
 
 
 @pytest.mark.filterwarnings("ignore:SS.read", "ignore:diff on read")

--- a/SSINS/tests/test_plot.py
+++ b/SSINS/tests/test_plot.py
@@ -7,13 +7,13 @@ import pytest
 
 
 @pytest.mark.filterwarnings("ignore:default base")
-def test_INS_plot():
+def test_INS_plot(tmp_path):
 
     matplotlib = pytest.importorskip("matplotlib")
 
     obs = '1061313128_99bl_1pol_half_time'
     insfile = os.path.join(DATA_PATH, f'{obs}_SSINS.h5')
-    outdir = os.path.join(DATA_PATH, 'test_plots')
+    outdir = os.path.join(tmp_path, 'test_plots')
 
     prefix = f'{outdir}/{obs}_raw'
     outfile = f'{prefix}_SSINS.pdf'
@@ -48,19 +48,14 @@ def test_INS_plot():
     assert os.path.exists(log_outfile), "The second plot was not made"
     assert os.path.exists(symlog_outfile), "The third plot was not made"
 
-    os.remove(outfile)
-    os.remove(log_outfile)
-    os.remove(symlog_outfile)
-    os.rmdir(outdir)
 
-
-def test_sig_plot():
+def test_sig_plot(tmp_path):
 
     matplotlib = pytest.importorskip("matplotlib")
 
     obs = '1061313128_99bl_1pol_half_time'
     insfile = os.path.join(DATA_PATH, f'{obs}_SSINS.h5')
-    outdir = os.path.join(DATA_PATH, 'test_plots')
+    outdir = os.path.join(tmp_path, 'test_plots')
 
     prefix = '%s/%s_flagged' % (outdir, obs)
     dataplotfile = '%s_SSINS.pdf' % prefix
@@ -84,19 +79,15 @@ def test_sig_plot():
     assert os.path.exists(outfile), "The first plot was not made"
     assert os.path.exists(dataplotfile), "The second plot was not made"
 
-    os.remove(outfile)
-    os.remove(dataplotfile)
-    os.rmdir(outdir)
-
 
 @pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")
-def test_VDH_plot():
+def test_VDH_plot(tmp_path):
 
     matplotlib = pytest.importorskip("matplotlib")
 
     obs = '1061313128_99bl_1pol_half_time'
     testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
-    outdir = os.path.join(DATA_PATH, 'test_plots')
+    outdir = os.path.join(tmp_path, 'test_plots')
 
     prefix = f'{outdir}/{obs}'
     outfile = f'{prefix}_VDH.pdf'
@@ -114,19 +105,15 @@ def test_VDH_plot():
     assert os.path.exists(outfile), "The first plot was not made"
     assert os.path.exists(dens_outfile), "The second plot was not made"
 
-    os.remove(outfile)
-    os.remove(dens_outfile)
-    os.rmdir(outdir)
-
 
 @pytest.mark.filterwarnings("ignore:SS.read", "ignore:Reordering")
-def test_VDH_no_model():
+def test_VDH_no_model(tmp_path):
 
     matplotlib = pytest.importorskip("matplotlib")
 
     obs = '1061313128_99bl_1pol_half_time'
     testfile = os.path.join(DATA_PATH, f'{obs}.uvfits')
-    outdir = os.path.join(DATA_PATH, 'test_plots')
+    outdir = os.path.join(tmp_path, 'test_plots')
     prefix = f'{outdir}/{obs}'
     outfile = f'{prefix}_VDH.pdf'
 
@@ -137,6 +124,3 @@ def test_VDH_no_model():
         cp.VDH_plot(ss, prefix, pre_model=False, post_model=False)
 
     assert os.path.exists(outfile), "The plot was not made"
-
-    os.remove(outfile)
-    os.rmdir(outdir)

--- a/SSINS/tests/test_util.py
+++ b/SSINS/tests/test_util.py
@@ -35,7 +35,7 @@ def test_event_count():
     assert util.event_count(event_list, time_range) == 10
 
 
-def test_calc_occ():
+def test_calc_occ(tmp_path):
 
     obs = "1061313128_99bl_1pol_half_time_SSINS"
     testfile = os.path.join(DATA_PATH, f"{obs}.h5")

--- a/ci/SSINS_tests.yml
+++ b/ci/SSINS_tests.yml
@@ -17,5 +17,5 @@ dependencies:
      - pytest-cases>=3
      - pytest-xdist
   - pyyaml>=5.3.1
-  - pyuvdata>=2.1.2
+  - pyuvdata>=2.2.9
   - matplotlib>=3.2.2

--- a/ci/SSINS_tests.yml
+++ b/ci/SSINS_tests.yml
@@ -1,7 +1,6 @@
 name: SSINS_tests
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - astropy
   - numpy
@@ -17,5 +16,5 @@ dependencies:
      - pytest-cases>=3
      - pytest-xdist
   - pyyaml>=5.3.1
-  - pyuvdata=2.2.8
+  - pyuvdata=2.2.9
   - matplotlib>=3.2.2

--- a/ci/SSINS_tests.yml
+++ b/ci/SSINS_tests.yml
@@ -17,5 +17,5 @@ dependencies:
      - pytest-cases>=3
      - pytest-xdist
   - pyyaml>=5.3.1
-  - pyuvdata=2.2.8
+  - pyuvdata>=2.2.8
   - matplotlib>=3.2.2

--- a/ci/SSINS_tests.yml
+++ b/ci/SSINS_tests.yml
@@ -17,5 +17,5 @@ dependencies:
      - pytest-cases>=3
      - pytest-xdist
   - pyyaml>=5.3.1
-  - pyuvdata>=2.2.9
+  - pyuvdata=2.2.8
   - matplotlib>=3.2.2

--- a/ci/SSINS_tests.yml
+++ b/ci/SSINS_tests.yml
@@ -1,6 +1,7 @@
 name: SSINS_tests
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - astropy
   - numpy
@@ -16,5 +17,5 @@ dependencies:
      - pytest-cases>=3
      - pytest-xdist
   - pyyaml>=5.3.1
-  - pyuvdata=2.2.9
+  - pyuvdata=2.2.8
   - matplotlib>=3.2.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ copyright = u'2018, Michael Wilensky'
 author = u'Michael Wilensky'
 
 # The short X.Y version
-version = u'1.4.5'
+version = u'1.4.6'
 # The full version, including alpha/beta/rc tags
 release = u''
 

--- a/docs/rtd-env.yml
+++ b/docs/rtd-env.yml
@@ -3,7 +3,7 @@ name: rtd
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.10
   - numpy
   - scipy
   - astropy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
There is an issue with the windows builds probably related to astropy, see #114 The goal is to bring this from failing to passing using better unit tests.

## Description
<!--- Describe your changes in detail -->
TODO LIST
- [x] Change pyuvdata version specification back to what the actual dependency is
- [x] Implement the `tmp_path` fixture from pytest
- [ ] Potentially make the test variations a little cleaner using pytest's `parameterizations`
- [x] Change python matrix to 3.8, 3.9, 3.10

## Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->

Main Code Body Checklist:
- [ ] Add or update docstring related to code change
- [x] Add a unit test that verifies the efficacy of the code
- [ ] Write a tutorial if the feature would be useful to others to use
- [x] Update CHANGELOG.md

Scripts Checklist:
- [ ] Add useful help strings for any arguments that are parsed
- [ ] Manually check that the script runs and gives proper results
- [ ] Update CHANGELOG.md
