### PR TITLE
Fixes to ensure future pyuvdata compatibility

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@main
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Setup Minimamba
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -23,13 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Minimamba
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Setup Miniforge
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           miniconda-version: "latest"
-          miniforge-variant: Mambaforge
-          use-mamba: true
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yml
           activate-environment: ${{ env.ENV_NAME }}
@@ -72,13 +70,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup Minimamba
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Setup Miniforge
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           miniconda-version: "latest"
-          miniforge-variant: Mambaforge
-          use-mamba: true
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yml
           activate-environment: ${{ env.ENV_NAME }}

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -659,8 +659,8 @@ class INS(UVFlag):
         ins.metric_array.mask = np.copy(mask_uvf.flag_array)
         # The constructor calls UVFlag.__init__, which can call from_uvdata
         # from_uvdata can call select depending on spectrum type
-        # We want to recalculate data_params only if select is being done outside of from_uvdata (or read, but that functionality does not exist yet)
-        # data_params are set at the end of from_uvdata, or read, so checking this is meant to check if those are done
+        # We want to recalculate data_params only if select is being done outside of from_uvdata or read
+        # ins_data_params are set at the end of from_uvdata and read, so checking this is meant to check if those are done
         if self._has_ins_data_params:
             ins.set_ins_data_params()
             warnings.warn("sig_array has been reset")

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -657,9 +657,13 @@ class INS(UVFlag):
         super(INS, mask_uvf).select(inplace=True, **kwargs)
 
         ins.metric_array.mask = np.copy(mask_uvf.flag_array)
-        # In case this is called in the middle of the constructor.
-        if not self._has_ins_data_params:
+        # The constructor calls UVFlag.__init__, which can call from_uvdata
+        # from_uvdata can call select depending on spectrum type
+        # We want to recalculate data_params only if select is being done outside of from_uvdata (or read, but that functionality does not exist yet)
+        # data_params are set at the end of from_uvdata, or read, so checking this is meant to check if those are done
+        if self._has_ins_data_params:
             ins.set_ins_data_params()
+            warnings.warn("sig_array has been reset")
 
         if not inplace:
             return(ins)

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -289,8 +289,9 @@ def test_select(tv_ins_testfile):
     ins = INS(tv_ins_testfile)
     ins.metric_array.mask[7, :12] = True
 
-    new_ins = ins.select(times=ins.time_array[3:-3], freq_chans=np.arange(24),
-                         inplace=False)
+    with pytest.warns(UserWarning, match="sig_array has been reset"):
+        new_ins = ins.select(times=ins.time_array[3:-3], freq_chans=np.arange(24),
+                             inplace=False)
 
     Ntimes = len(ins.time_array)
     ins.select(times=ins.time_array[3:-3], freq_chans=np.arange(24))

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -346,7 +346,7 @@ def test_Nphase_gt_1(tmp_path, tv_testfile):
 @pytest.mark.filterwarnings("ignore:The shapes of several attributes will be changing")
 @pytest.mark.filterwarnings("ignore:Reordering data array to baseline order")
 @pytest.mark.filterwarnings("ignore:Some nsamples are 0, which will result in")
-def test_loop_read_write():
+def test_loop_read_write(tmpdir):
     """Taken from the tutorial which broke when all the tests passed."""
     ss = SS()
     filepath = os.path.join(DATA_PATH, '1061313128_99bl_1pol_half_time.uvfits')
@@ -358,6 +358,9 @@ def test_loop_read_write():
     uvd.read(filepath, times=times)
 
     ss.read(filepath, times=times, flag_choice='original', diff=True)
-    ss.write(
-        os.path.join('.', 'tutorial_test_writeout_2.uvfits'), 'uvfits', UV=uvd
-    )
+    write_path = os.path.join(tmpdir, 'tutorial_test_writeout_2.uvfits')
+    ss.write(write_path, 'uvfits', UV=uvd)
+
+    uvd2 = UVData.from_file(write_path)
+    uvd2._consolidate_phase_center_catalogs(reference_catalog=uvd.phase_center_catalog)
+    assert uvd2 == uvd

--- a/ci/SSINS_tests.yml
+++ b/ci/SSINS_tests.yml
@@ -1,7 +1,6 @@
 name: SSINS_tests
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - astropy
   - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=64", "wheel", "setuptools_scm>=8.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
 [build-system]
 requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,4 @@ requires = ["setuptools>=64", "wheel", "setuptools_scm>=8.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+version_file = "SSINS/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,8 @@
 requires = ["setuptools>=64", "wheel", "setuptools_scm>=8.1"]
 build-backend = "setuptools.build_meta"
 
+# This has to be here for Mac builds to work.
+# It's a bit weird to have this here and all the other metadata in setup.py,
+# The right thing long term is to move it all to this file.
 [tool.setuptools_scm]
 version_file = "SSINS/version.py"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Karto is working a major refactoring of `select` across all the pyuvdata classes (https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1523). The changes to UVFlag caused errors in the SSINS CI job.

The new code does the select by using the UVParameter form information to ensure that all arrays are properly selected. This broke the selection for the SSINS `metric_ms` and `sig_array` because those were not UVParameter objects.

This PR makes them UVParameters and tweaks some related code to make everything work properly. All the tests pass, but this is a significant change, so it's possible something about this breaks things in a subtle way that isn't covered by tests, so please take a careful look.

I also fixed a test that was writing a test file to my local SSINS directory and tweaked some CI and pyproject.toml things to get all the builds to work.

## Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->

Main Code Body Checklist:
- [ ] Add or update docstring related to code change
- [ ] Add a unit test that verifies the efficacy of the code
- [ ] Write a tutorial if the feature would be useful to others to use
- [ ] Update CHANGELOG.md

Scripts Checklist:
- [ ] Add useful help strings for any arguments that are parsed
- [ ] Manually check that the script runs and gives proper results
- [ ] Update CHANGELOG.md
