### PR TITLE
Warning cleanup

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@main
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # SSINS Change Log
 
 ## Unrealeased
-- Updates pyuvdata requirements to 3.1.4, which always uses future_array_shapes.
+- Updates pyuvdata requirements to 3.1.3, which always uses future_array_shapes.
+- Updates python requirement to 3.10
 
 ## 1.4.7
 - Added handling for negative `sig_thresh` such that when set, the associated shape will only trigger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SSINS Change Log
 
+## Unrealeased
+- Updates pyuvdata requirements to 3.1.4, which always uses future_array_shapes.
+
 ## 1.4.7
 - Added handling for negative `sig_thresh` such that when set, the associated shape will only trigger
 on a negative sig smaller than `sig_thresh`. Behavior for positive `sig_thresh` is unchanged;

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ SSINS is a python package intended for radio frequency interference flagging in 
 
 ## Dependencies
 
-**python3** is now required. Support for python2 has been dropped.<br/>
-**pyuvdata 3.1.4 or newer**.<br/>
+**python 3.10 or newer** is now required. <br/>
+**pyuvdata 3.1.3 or newer**.<br/>
 **pyuvdata has its own dependencies!**<br/>
 See https://github.com/RadioAstronomySoftwareGroup/pyuvdata.  
 **pyyaml 5.3.1 or newer** also for reading and writing SSINS outputs.  

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SSINS is a python package intended for radio frequency interference flagging in 
 ## Dependencies
 
 **python3** is now required. Support for python2 has been dropped.<br/>
-**pyuvdata 2.4.1 or newer**.<br/>
+**pyuvdata 3.1.4 or newer**.<br/>
 **pyuvdata has its own dependencies!**<br/>
 See https://github.com/RadioAstronomySoftwareGroup/pyuvdata.  
 **pyyaml 5.3.1 or newer** also for reading and writing SSINS outputs.  

--- a/SSINS/incoherent_noise_spectrum.py
+++ b/SSINS/incoherent_noise_spectrum.py
@@ -77,9 +77,12 @@ class INS(UVFlag):
 
         self.set_extra_params(order=order, spectrum_type=spectrum_type, use_integration_weights=use_integration_weights,
                               nsample_default=nsample_default, mask_file=mask_file, match_events_file=match_events_file)
-        super().__init__(indata=indata, mode='metric', copy_flags=False, waterfall=False, history=history, label=label, 
-                         use_future_array_shapes=True, run_check=run_check, check_extra=check_extra,
-                         run_check_acceptability=run_check_acceptability, **kwargs)
+        kwargs.pop("use_future_array_shapes", None)
+        super().__init__(indata=indata, mode='metric', copy_flags=False, 
+                         waterfall=False, history=history, label=label, 
+                         run_check=run_check, check_extra=check_extra,
+                         run_check_acceptability=run_check_acceptability, 
+                         **kwargs)
 
 
     def read(self, filename, history="", run_check=True, check_extra=True,
@@ -109,8 +112,9 @@ class INS(UVFlag):
         attr_dict = {attr: deepcopy(getattr(self, attr)) for attr in attrs}
 
         kwargs.pop("use_future_array_shapes", None)
-        super().read(filename, history=history, use_future_array_shapes=True, run_check=run_check,
-                     check_extra=check_extra, run_check_acceptability=run_check_acceptability, **kwargs)
+        super().read(filename, history=history, run_check=run_check,
+                     check_extra=check_extra, 
+                     run_check_acceptability=run_check_acceptability, **kwargs)
         
         self._pol_check()
         
@@ -135,7 +139,7 @@ class INS(UVFlag):
             self.metric_array.mask = self.weights_array == 0
         else:
             # Read in the flag array
-            flag_uvf = UVFlag(self.mask_file, use_future_array_shapes=True)
+            flag_uvf = UVFlag(self.mask_file)
             self.metric_array.mask = np.copy(flag_uvf.flag_array)
             del flag_uvf
 
@@ -230,8 +234,8 @@ class INS(UVFlag):
             raise ValueError("SS input has pseudo-Stokes data. SSINS does not"
                                 " currently support pseudo-Stokes spectra.")
 
-    def from_uvdata(self, indata, mode="metric", copy_flags=False, waterfall=False, history="",
-                    label="", run_check=True, check_extra=True,
+    def from_uvdata(self, indata, mode="metric", copy_flags=False, waterfall=False, 
+                    history="", label="", run_check=True, check_extra=True,
                     run_check_acceptability=True, **kwargs):
         """
         Construct an INS object from a UVData (SS) object. This is called during instantiation, but due to inheritance 
@@ -256,8 +260,9 @@ class INS(UVFlag):
         # will turn to waterfall later. These are just here to match signature.
         kwargs.pop("use_future_array_shapes", None)
         super().from_uvdata(indata, mode="metric", copy_flags=False, waterfall=False, 
-                            history=history, label=label, use_future_array_shapes=True,
-                            run_check=run_check, check_extra=check_extra, run_check_acceptability=run_check_acceptability,
+                            history=history, label=label,
+                            run_check=run_check, check_extra=check_extra, 
+                            run_check_acceptability=run_check_acceptability,
                             **kwargs)
         
         self._pol_check()

--- a/SSINS/sky_subtract.py
+++ b/SSINS/sky_subtract.py
@@ -44,7 +44,7 @@ class SS(UVData):
         """
 
         kwargs.pop("use_future_array_shapes", None)
-        super().read(filename, use_future_array_shapes=True, **kwargs)
+        super().read(filename, **kwargs)
         if self.Nphase > 1:
             raise NotImplementedError("SSINS cannot handle files with more than one phase center.")
 
@@ -344,9 +344,8 @@ class SS(UVData):
             self.reorder_blts(order='baseline')
         if UV is None:
             UV = UVData()
-            UV.read(filename_in, use_future_array_shapes=True, **read_kwargs)
-        else:
-            UV.use_future_array_shapes()
+            read_kwargs.pop("use_future_array_shapes", None)
+            UV.read(filename_in, **read_kwargs)
 
         # Option to keep old flags
         if not combine:

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -336,7 +336,7 @@ def test_spectrum_type_file_init(cross_testfile, tv_ins_testfile):
     del ins
     ins = INS(auto_testfile, spectrum_type="auto")
 
-
+@pytest.mark.filterwarnings("ignore:channel_width", "ignore:telescope_name", "ignore:Antenna", "ignore:telescope_location")
 def test_old_file():
     old_ins_file = os.path.join(DATA_PATH, "1061313128_99bl_1pol_half_time_old_SSINS.h5")
     try:

--- a/SSINS/tests/test_INS.py
+++ b/SSINS/tests/test_INS.py
@@ -137,22 +137,22 @@ def test_mask_to_flags(tmp_path, tv_obs, tv_testfile):
     ss.read(tv_testfile, diff=True)
 
     uvd = UVData()
-    uvd.read(tv_testfile, use_future_array_shapes=True)
+    uvd.read(tv_testfile)
 
-    uvf = UVFlag(uvd, mode='flag', waterfall=True, use_future_array_shapes=True)
+    uvf = UVFlag(uvd, mode='flag', waterfall=True)
     # start with some flags so that we can test the intended OR operation
     uvf.flag_array[6, :] = True
     ins = INS(ss)
 
     # Check error handling
     with pytest.raises(ValueError):
-        bad_uvf = UVFlag(uvd, mode='metric', waterfall=True, use_future_array_shapes=True)
+        bad_uvf = UVFlag(uvd, mode='metric', waterfall=True)
         err_uvf = ins.flag_uvf(uvf=bad_uvf)
     with pytest.raises(ValueError):
-        bad_uvf = UVFlag(uvd, mode='flag', waterfall=False, use_future_array_shapes=True)
+        bad_uvf = UVFlag(uvd, mode='flag', waterfall=False)
         err_uvf = ins.flag_uvf(uvf=bad_uvf)
     with pytest.raises(ValueError):
-        bad_uvf = UVFlag(uvd, mode='flag', waterfall=True, use_future_array_shapes=True)
+        bad_uvf = UVFlag(uvd, mode='flag', waterfall=True)
         # Pretend the data is off by 1 day
         bad_uvf.time_array += 1
         err_uvf = ins.flag_uvf(uvf=bad_uvf)
@@ -191,7 +191,7 @@ def test_mask_to_flags(tmp_path, tv_obs, tv_testfile):
 
     # Test write/read
     ins.write(prefix, output_type='flags', uvf=uvf)
-    read_uvf = UVFlag(flags_outfile, mode='flag', waterfall=True, use_future_array_shapes=True)
+    read_uvf = UVFlag(flags_outfile, mode='flag', waterfall=True)
     # Check equality
     assert read_uvf == uvf, "UVFlag object differs after read"
 

--- a/SSINS/tests/test_SS.py
+++ b/SSINS/tests/test_SS.py
@@ -45,7 +45,7 @@ def test_diff(tv_testfile):
     uv = UVData()
 
     # Read in two times and two baselines of data, so that the diff is obvious.
-    uv.read(tv_testfile, read_data=False, use_future_array_shapes=True)
+    uv.read(tv_testfile, read_data=False)
     times = np.unique(uv.time_array)[:2]
     if hasattr(uv, "telescope"):
         bls = [
@@ -58,7 +58,7 @@ def test_diff(tv_testfile):
             (uv.antenna_numbers[0], uv.antenna_numbers[1]),
             (uv.antenna_numbers[0], uv.antenna_numbers[2])
         ]
-    uv.read(tv_testfile, times=times, bls=bls, use_future_array_shapes=True)
+    uv.read(tv_testfile, times=times, bls=bls)
     uv.reorder_blts(order='baseline')
 
     diff_dat = uv.data_array[1::2] - uv.data_array[::2]
@@ -247,7 +247,7 @@ def test_write(tmp_path, tv_testfile):
 
     # Check if the flags propagated correctly
     UV = UVData()
-    UV.read(outfile, use_future_array_shapes=True)
+    UV.read(outfile)
     blt_inds = np.isin(UV.time_array, np.unique(UV.time_array)[10:12])
     assert np.all(UV.flag_array[blt_inds, 64:128, :]), "Not all expected flags were propagated"
 
@@ -257,7 +257,7 @@ def test_write(tmp_path, tv_testfile):
     # Test bad read.
     bad_uv_filepath = os.path.join(DATA_PATH, '1061312640_mix.uvfits')
     bad_uv = UVData()
-    bad_uv.read(bad_uv_filepath, use_future_array_shapes=True)
+    bad_uv.read(bad_uv_filepath)
     with pytest.raises(ValueError, match="UVData and SS objects were found to be incompatible."):
         ss.write(outfile, 'uvfits', bad_uv)
 
@@ -270,15 +270,15 @@ def test_read_multifiles(tmp_path, tv_obs, tv_testfile):
 
     # Read in a file's metadata and split it into two objects
     uvd_full = UVData()
-    uvd_full.read(tv_testfile, read_data=False, use_future_array_shapes=True)
+    uvd_full.read(tv_testfile, read_data=False)
     times1 = np.unique(uvd_full.time_array)[:14]
     times2 = np.unique(uvd_full.time_array)[14:]
 
     # Write two separate files to be read in later
     uvd_split1 = UVData()
     uvd_split2 = UVData()
-    uvd_split1.read(tv_testfile, times=times1, use_future_array_shapes=True)
-    uvd_split2.read(tv_testfile, times=times2, use_future_array_shapes=True)
+    uvd_split1.read(tv_testfile, times=times1)
+    uvd_split2.read(tv_testfile, times=times2)
     uvd_split1.write_uvfits(new_fp1)
     uvd_split2.write_uvfits(new_fp2)
 
@@ -312,16 +312,16 @@ def test_newmask(tv_testfile):
 
 
 def test_Nphase_gt_1(tmp_path, tv_testfile):
-    uvd = UVData.from_file(tv_testfile, read_data=False, use_future_array_shapes=True)
+    uvd = UVData.from_file(tv_testfile, read_data=False)
 
     # Split the object so we can phase to separate locations
     unique_times = np.unique(uvd.time_array)
     first_times = unique_times[:10]
     last_times = unique_times[-10:]
 
-    uvfirst = UVData.from_file(tv_testfile, times=first_times, use_future_array_shapes=True)
+    uvfirst = UVData.from_file(tv_testfile, times=first_times)
 
-    uvlast = UVData.from_file(tv_testfile, times=last_times, use_future_array_shapes=True)
+    uvlast = UVData.from_file(tv_testfile, times=last_times)
 
     # Adjust phase of one object and write new file
     og_pc_ra = uvd.phase_center_app_ra[0]

--- a/SSINS/tests/test_util.py
+++ b/SSINS/tests/test_util.py
@@ -227,10 +227,10 @@ def test_write_meta(tmp_path):
     testfile = os.path.join(DATA_PATH, f"{obs}.uvfits")
     prefix = os.path.join(tmp_path, f"{obs}_test")
 
-    uvd = UVData.from_file(testfile, freq_chans=np.arange(32), use_future_array_shapes=True)
+    uvd = UVData.from_file(testfile, freq_chans=np.arange(32))
     ss = SS()
     ss.read(testfile, freq_chans=np.arange(32), diff=True)
-    uvf = UVFlag(uvd, mode="flag", waterfall=True, use_future_array_shapes=True)
+    uvf = UVFlag(uvd, mode="flag", waterfall=True)
     ins = INS(ss)
 
     ins.metric_array[:] = 1

--- a/SSINS/tests/test_util.py
+++ b/SSINS/tests/test_util.py
@@ -34,7 +34,7 @@ def test_event_count():
 
     assert util.event_count(event_list, time_range) == 10
 
-
+@pytest.mark.filterwarnings("ignore: sig_array")
 def test_calc_occ(tmp_path):
 
     obs = "1061313128_99bl_1pol_half_time_SSINS"

--- a/ci/SSINS_tests.yml
+++ b/ci/SSINS_tests.yml
@@ -16,5 +16,5 @@ dependencies:
      - pytest-cases>=3
      - pytest-xdist
   - pyyaml>=5.3.1
-  - pyuvdata>=3.1.4
+  - pyuvdata>=3.1.3
   - matplotlib>=3.2.2

--- a/ci/SSINS_tests.yml
+++ b/ci/SSINS_tests.yml
@@ -16,5 +16,5 @@ dependencies:
      - pytest-cases>=3
      - pytest-xdist
   - pyyaml>=5.3.1
-  - pyuvdata>=2.4.1
+  - pyuvdata>=3.1.4
   - matplotlib>=3.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ description = "RFI flagging package for radio arrays"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "pyuvdata>=2.4.1",
+    "pyuvdata>=3.1.4",
 ]
 requires-python = ">=3.9"
 keywords = ["radio frequency interference"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ description = "RFI flagging package for radio arrays"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "pyuvdata>=3.1.4",
+    "pyuvdata>=3.1.3",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["radio frequency interference"]
 classifiers = [
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This cleans up a bunch of warnings in the tests, along with some related changes. 

## Description
<!--- Describe your changes in detail -->
It also essentially abandons passing the `use_future_array_shapes` kwarg into the pyuvdata reading functions because pyuvdata does not support these. It will still pop the kwarg before reading, in case someone passed it in with old code. I have updated the pyuvdata requirements accordingly.

## Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->

Main Code Body Checklist:
- [x ] Add or update docstring related to code change
- [x ] Add a unit test that verifies the efficacy of the code
- [ ] Write a tutorial if the feature would be useful to others to use
- [x ] Update CHANGELOG.md

Scripts Checklist:
- [ ] Add useful help strings for any arguments that are parsed
- [ ] Manually check that the script runs and gives proper results
- [ ] Update CHANGELOG.md
